### PR TITLE
[Observability] Allows setting parent scope manually.

### DIFF
--- a/src/Observability/Runtime/Tracing/Scopes/ExecuteToolScope.cs
+++ b/src/Observability/Runtime/Tracing/Scopes/ExecuteToolScope.cs
@@ -4,7 +4,6 @@
 
 using System.Diagnostics;
 using Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts;
-using static Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes.OpenTelemetryConstants;
 
 namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
 {
@@ -22,15 +21,16 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
         /// Creates and starts a new scope for tool execution tracing.
         /// </summary>
         /// <returns>A new ExecuteToolScope instance.</returns>
-        public static ExecuteToolScope Start(ToolCallDetails details, AgentDetails agentDetails, TenantDetails tenantDetails) => new ExecuteToolScope(details, agentDetails, tenantDetails);
+        public static ExecuteToolScope Start(ToolCallDetails details, AgentDetails agentDetails, TenantDetails tenantDetails, string? parentId = null) => new ExecuteToolScope(details, agentDetails, tenantDetails, parentId);
 
-        private ExecuteToolScope(ToolCallDetails details, AgentDetails agentDetails, TenantDetails tenantDetails)
+        private ExecuteToolScope(ToolCallDetails details, AgentDetails agentDetails, TenantDetails tenantDetails, string? parentId = null)
             : base(
                 ActivityKind.Internal,
                 agentDetails,
                 tenantDetails,
                 OperationName,
-                $"{OperationName} {details.ToolName}")
+                $"{OperationName} {details.ToolName}",
+                parentId: parentId)
         {
             var (toolName, arguments, toolCallId, description, toolType, endpoint) = details;
             SetTagMaybe(OpenTelemetryConstants.GenAiToolNameKey, toolName);

--- a/src/Observability/Runtime/Tracing/Scopes/InferenceScope.cs
+++ b/src/Observability/Runtime/Tracing/Scopes/InferenceScope.cs
@@ -12,15 +12,16 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
         /// <summary>
         /// Creates and starts a new scope for inference tracing.
         /// </summary>
-        public static InferenceScope Start(InferenceCallDetails details, AgentDetails agentDetails, TenantDetails tenantDetails) => new InferenceScope(details, agentDetails, tenantDetails);
+        public static InferenceScope Start(InferenceCallDetails details, AgentDetails agentDetails, TenantDetails tenantDetails, string? parentId = null) => new InferenceScope(details, agentDetails, tenantDetails, parentId);
 
-        private InferenceScope(InferenceCallDetails details, AgentDetails agentDetails, TenantDetails tenantDetails)
+        private InferenceScope(InferenceCallDetails details, AgentDetails agentDetails, TenantDetails tenantDetails, string? parentId = null)
             : base(
                 ActivityKind.Client,
                 agentDetails,
                 tenantDetails,
                 details.OperationName.ToString(),
-                $"{details.OperationName} {details.Model}")
+                $"{details.OperationName} {details.Model}",
+                parentId: parentId)
         {
             SetTagMaybe(GenAiOperationNameKey, details.OperationName.ToString());
             SetTagMaybe(GenAiRequestModelKey, details.Model);

--- a/src/Observability/Runtime/Tracing/Scopes/OpenTelemetryScope.cs
+++ b/src/Observability/Runtime/Tracing/Scopes/OpenTelemetryScope.cs
@@ -44,10 +44,21 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
         /// <param name="operationName">The name of the operation being traced.</param>
         /// <param name="activityName">The name of the activity for display purposes.</param>
         /// <param name="startTime">Optional custom start time for the scope. If not provided, the current time is used.</param>
-        protected OpenTelemetryScope(ActivityKind kind, AgentDetails agentDetails, TenantDetails tenantDetails, string operationName, string activityName, DateTimeOffset? startTime = null)
+        /// <param name="parentId">Optional parent ID for the activity.</param>
+        protected OpenTelemetryScope(ActivityKind kind, AgentDetails agentDetails, TenantDetails tenantDetails, string operationName, string activityName, DateTimeOffset? startTime = null, string? parentId = null)
         {
             customStartTime = startTime;
-            activity = ActivitySource.StartActivity(activityName, kind, default(ActivityContext), startTime: startTime ?? default);
+            activity = ActivitySource.CreateActivity(activityName, kind, default(ActivityContext));
+            if (!string.IsNullOrEmpty(parentId))
+            {
+                activity?.SetParentId(parentId!);
+            }
+
+            if (startTime != null) 
+            {
+                activity?.SetStartTime(startTime.Value.UtcDateTime);
+            }
+
             commonTags = new TagList
                 {
                     { GenAiOperationNameKey, operationName },
@@ -75,6 +86,8 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
             {
                 duration = Stopwatch.StartNew();
             }
+
+            activity?.Start();
         }
 
         /// <summary>
@@ -210,5 +223,10 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
         {
             activity?.AddBaggage(key, value);
         }
+
+        /// <summary>
+        /// Gets the span ID for the current activity.
+        /// </summary>
+        public string Id => activity?.Id ?? string.Empty;
     }
 }

--- a/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/Common/ExportFormatterTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/Common/ExportFormatterTests.cs
@@ -2,85 +2,23 @@ using System.Diagnostics;
 using System.Text.Json;
 using FluentAssertions;
 using Microsoft.Agents.A365.Observability.Runtime.Common;
+using Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts;
+using Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes;
+using Microsoft.Agents.A365.Observability.Tests.Tracing;
+using Microsoft.Agents.A365.Observability.Tests.Tracing.Scopes;
 using OpenTelemetry.Resources;
 
 namespace Microsoft.Agents.A365.Observability.Runtime.Tests.Common
 {
-    [TestClass]
-    public class ExportFormatterTests
+    public sealed class TestScope : OpenTelemetryScope
     {
-        private static Activity CreateActivity(
-            string sourceName = "TestSource",
-            string? sourceVersion = "1.2.3",
-            string displayName = "test-span",
-            ActivityKind kind = ActivityKind.Server,
-            DateTime? startTimeUtc = null,
-            TimeSpan? duration = null,
-            Dictionary<string, object>? tags = null,
-            List<ActivityEvent>? events = null,
-            List<ActivityLink>? links = null,
-            ActivitySpanId? parentSpanId = null,
-            ActivityStatusCode status = ActivityStatusCode.Ok,
-            string? statusDescription = null)
-        {
-            var source = new ActivitySource(sourceName, sourceVersion);
+        public TestScope(ActivityKind kind, AgentDetails agentDetails, TenantDetails tenantDetails, string operationName, string activityName)
+            : base(kind, agentDetails, tenantDetails, operationName, activityName) { }
+    }
 
-            using var listener = new ActivityListener
-            {
-                ShouldListenTo = s => s.Name == sourceName,
-                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-                ActivityStarted = _ => { },
-                ActivityStopped = _ => { }
-            };
-            ActivitySource.AddActivityListener(listener);
-
-            Activity? activity;
-            if (parentSpanId.HasValue)
-            {
-                var parentContext = new ActivityContext(
-                    ActivityTraceId.CreateRandom(),
-                    parentSpanId.Value,
-                    ActivityTraceFlags.Recorded);
-                activity = source.StartActivity(displayName, kind, parentContext);
-            }
-            else
-            {
-                activity = source.StartActivity(displayName, kind);
-            }
-
-            if (activity == null)
-                throw new InvalidOperationException("Failed to start activity.");
-
-            if (startTimeUtc.HasValue)
-                activity.SetStartTime(startTimeUtc.Value);
-
-            if (duration.HasValue)
-                activity.SetEndTime(activity.StartTimeUtc + duration.Value);
-
-            if (tags != null)
-            {
-                foreach (var tag in tags)
-                    activity.SetTag(tag.Key, tag.Value);
-            }
-
-            if (events != null)
-            {
-                foreach (var ev in events)
-                    activity.AddEvent(ev);
-            }
-
-            if (links != null)
-            {
-                foreach (var link in links)
-                    activity.AddLink(link);
-            }
-
-            activity.SetStatus(status, statusDescription);
-
-            activity.Stop();
-            return activity;
-        }
-
+    [TestClass]
+    public partial class ExportFormatterTests : ActivityTest
+    {
         private static Resource CreateResource(Dictionary<string, object>? attributes = null)
         {
             var builder = ResourceBuilder.CreateEmpty();
@@ -132,7 +70,6 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tests.Common
 
             var activity = CreateActivity(
                 sourceName: "TestSource",
-                sourceVersion: "1.2.3",
                 displayName: "span1",
                 kind: ActivityKind.Client,
                 startTimeUtc: startTime,
@@ -158,7 +95,6 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tests.Common
 
             var scope = scopeSpans[0].GetProperty("scope");
             scope.GetProperty("name").GetString().Should().Be("TestSource");
-            scope.GetProperty("version").GetString().Should().Be("1.2.3");
 
             var spans = scopeSpans[0].GetProperty("spans");
             spans.GetArrayLength().Should().Be(1);
@@ -193,9 +129,9 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tests.Common
         public void Format_MultipleActivities_GroupedBySource()
         {
             // Arrange
-            var act1 = CreateActivity(sourceName: "SourceA", sourceVersion: "1.0", displayName: "spanA");
-            var act2 = CreateActivity(sourceName: "SourceA", sourceVersion: "1.0", displayName: "spanB");
-            var act3 = CreateActivity(sourceName: "SourceB", sourceVersion: "2.0", displayName: "spanC");
+            var act1 = CreateActivity(sourceName: "SourceA", displayName: "spanA");
+            var act2 = CreateActivity(sourceName: "SourceA", displayName: "spanB");
+            var act3 = CreateActivity(sourceName: "SourceB", displayName: "spanC");
 
             var activities = new List<Activity> { act1, act2, act3 };
             var resource = CreateResource(new Dictionary<string, object> { { "env", "test" } });
@@ -245,23 +181,30 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tests.Common
         }
 
         [TestMethod]
-        public void Format_ParentSpanId_IsMapped()
+        public void Format_ManuallySetParentId_IsReflectedInExport()
         {
             // Arrange
-            var parentSpanId = ActivitySpanId.CreateRandom();
-            var act = CreateActivity(parentSpanId: parentSpanId);
-            var resource = CreateResource();
+            var manualParentActivity = CreateActivity();
+            var parentId = manualParentActivity.Id ?? string.Empty;
+            var parentSpanId = manualParentActivity.SpanId.ToString();
+            var activity = ListenForActivity(() =>
+            {
+                using var toolScope = ExecuteToolScope.Start(new ToolCallDetails("TestTool", "Input: 42"), Util.GetAgentDetails(), Util.GetTenantDetails(), parentId);
+            });
+
+            var resource = ResourceBuilder.CreateDefault().Build();
 
             // Act
-            var json = ExportFormatter.Format(new[] { act }, resource);
+            var json = ExportFormatter.Format(new[] { activity! }, resource);
 
             // Assert
-            var doc = JsonDocument.Parse(json);
+            using var doc = JsonDocument.Parse(json);
             var resourceSpans = doc.RootElement.GetProperty("resourceSpans");
             var scopeSpans = resourceSpans[0].GetProperty("scopeSpans");
-            var span = scopeSpans[0].GetProperty("spans")[0];
-            var parentSpanIdJson = span.GetProperty("parentSpanId").GetString();
-            parentSpanIdJson.Should().Be(parentSpanId.ToHexString().ToLowerInvariant());
+            var spans = scopeSpans[0].GetProperty("spans");
+            var span = spans[0];
+            var parentSpanIdJson = span.GetProperty("parentSpanId").GetString()?.ToLowerInvariant();
+            parentSpanIdJson.Should().Be(parentSpanId.ToLowerInvariant());
         }
 
         [TestMethod]

--- a/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/Tracing/Processors/ActivityTest.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/Tracing/Processors/ActivityTest.cs
@@ -41,4 +41,75 @@ public abstract class ActivityTest
         startedActivity.Should().NotBeNull();
         return startedActivity!;
     }
+
+    protected Activity CreateActivity(
+            string sourceName = SourceName,
+            string displayName = "test-span",
+            ActivityKind kind = ActivityKind.Server,
+            DateTime? startTimeUtc = null,
+            TimeSpan? duration = null,
+            Dictionary<string, object>? tags = null,
+            List<ActivityEvent>? events = null,
+            List<ActivityLink>? links = null,
+            ActivitySpanId? parentSpanId = null,
+            ActivityStatusCode status = ActivityStatusCode.Ok,
+            string? statusDescription = null)
+    {
+        var source = new ActivitySource(sourceName);
+
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == sourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStarted = _ => { },
+            ActivityStopped = _ => { }
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        Activity? activity;
+        if (parentSpanId.HasValue)
+        {
+            var parentContext = new ActivityContext(
+                ActivityTraceId.CreateRandom(),
+                parentSpanId.Value,
+                ActivityTraceFlags.Recorded);
+            activity = source.StartActivity(displayName, kind, parentContext);
+        }
+        else
+        {
+            activity = source.StartActivity(displayName, kind);
+        }
+
+        if (activity == null)
+            throw new InvalidOperationException("Failed to start activity.");
+
+        if (startTimeUtc.HasValue)
+            activity.SetStartTime(startTimeUtc.Value);
+
+        if (duration.HasValue)
+            activity.SetEndTime(activity.StartTimeUtc + duration.Value);
+
+        if (tags != null)
+        {
+            foreach (var tag in tags)
+                activity.SetTag(tag.Key, tag.Value);
+        }
+
+        if (events != null)
+        {
+            foreach (var ev in events)
+                activity.AddEvent(ev);
+        }
+
+        if (links != null)
+        {
+            foreach (var link in links)
+                activity.AddLink(link);
+        }
+
+        activity.SetStatus(status, statusDescription);
+
+        activity.Stop();
+        return activity;
+    }
 }

--- a/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/Tracing/Scopes/ScopeTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/Tracing/Scopes/ScopeTests.cs
@@ -9,17 +9,26 @@ using static Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes.OpenTele
 [TestClass]
 public sealed class ScopeTests : ActivityTest
 {
+    private class TestScope : OpenTelemetryScope
+    {
+        public TestScope(ActivityKind kind, AgentDetails agentDetails, TenantDetails tenantDetails, string operationName, string activityName)
+            : base(kind, agentDetails, tenantDetails, operationName, activityName) { }
+    }
+
     [TestMethod]
     public void NestedScope_PropagatesAgentId()
     {
+        // Arrange
         using var tracerProvider = ConstructTracerProvider();
 
+        // Act
         var activity = ListenForActivity(() =>
         {
             using var invokeAgentScope = InvokeAgentScope.Start(Details, Util.GetTenantDetails());
             using var toolScope = ExecuteToolScope.Start(new ToolCallDetails("TestTool", "Input: 42"), Util.GetAgentDetails(), Util.GetTenantDetails());
         });
-        
+
+        // Assert
         activity.Should().NotBeNull();
         activity.Kind.Should().Be(ActivityKind.Internal);
         activity.TagObjects.Should().ContainKey(GenAiOperationNameKey)
@@ -27,5 +36,46 @@ public sealed class ScopeTests : ActivityTest
         activity.TagObjects.Should().ContainKey(GenAiAgentIdKey)
             .WhoseValue.Should().BeOfType<string>()
             .Which.Should().Be(AgentId);
+    }
+
+    [TestMethod]
+    public void Id_ReturnsActivityId()
+    {
+        // Arrange
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == SourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStarted = _ => { },
+            ActivityStopped = _ => { }
+        };
+        ActivitySource.AddActivityListener(listener);
+        
+        using var scope = new TestScope(ActivityKind.Internal, Util.GetAgentDetails(), Util.GetTenantDetails(), "TestOperation", "TestActivity");
+        
+        // Act
+        var expectedId = scope.Id;
+
+        // Assert
+        expectedId.Should().NotBeNullOrEmpty();
+    }
+
+    [TestMethod]
+    public void SetParentId_SetsActivityParentId()
+    {
+        // Arrange
+        var manualParentActivity = CreateActivity();
+        var parentId = manualParentActivity.Id;
+        var parentSpanId = manualParentActivity.SpanId.ToString() ?? string.Empty;
+
+        // Act
+        var activity = ListenForActivity(() =>
+        {
+            using var toolScope = ExecuteToolScope.Start(new ToolCallDetails("TestTool", "Input: 42"), Util.GetAgentDetails(), Util.GetTenantDetails(), parentId);
+        });
+        
+        // Assert
+        activity.Should().NotBeNull();
+        activity!.ParentSpanId.ToString().Should().Be(parentSpanId);
     }
 }


### PR DESCRIPTION
Some agents are multi process, they need to be able to emit scopes from different processes. This PR adds support to manually set the parent span so that scenario can correctly set a parent-children structure.