### PR TITLE
Propagate agent details.

### DIFF
--- a/src/Observability/Runtime/Tracing/Scopes/OpenTelemetryScope.cs
+++ b/src/Observability/Runtime/Tracing/Scopes/OpenTelemetryScope.cs
@@ -74,6 +74,9 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
                 SetTagMaybe(GenAiAgentIdKey, agentDetails.AgentId);
                 SetTagMaybe(GenAiAgentNameKey, agentDetails.AgentName);
                 SetTagMaybe(GenAiAgentDescriptionKey, agentDetails.AgentDescription);
+                SetTagMaybe(GenAiAgentAUIDKey, agentDetails.AgentAUID);
+                SetTagMaybe(GenAiAgentUPNKey, agentDetails.AgentUPN);
+                SetTagMaybe(GenAiAgentBlueprintIdKey, agentDetails.AgentBlueprintId);
             }
 
             if (tenantDetails != null)


### PR DESCRIPTION
Few agent details are never set in OpenTelemetryScope. Fixing this.