### PR TITLE
Add methods for creating EmailResponse activities

### DIFF
--- a/src/Notification/Microsoft.Agents.A365.Notifications/AgentNotification.cs
+++ b/src/Notification/Microsoft.Agents.A365.Notifications/AgentNotification.cs
@@ -286,5 +286,28 @@ namespace AgentNotification
             {
                 a365.OnLifecycleNotification(Events.AgenticUserDeleted, routeHandler, rank, autoSignInHandlers);
             });
+
+        /// <summary>
+        /// Creates a reply Activity containing an <see cref="EmailResponse"/> entity populated with the provided HTML body.
+        /// </summary>
+        /// <param name="activity">The source Activity this reply is based on. Routing/conversation metadata is copied via <see cref="IActivity.CreateReply(string, string)"/>.</param>
+        /// <param name="emailResponseHtmlBody">The HTML body content to include in the <see cref="EmailResponse"/> entity.</param>
+        /// <returns>
+        /// A new <see cref="IActivity"/> reply whose <c>Entities</c> collection includes an <see cref="EmailResponse"/> carrying the supplied HTML body.
+        /// </returns>
+        /// <remarks>
+        /// This helper wraps two operations:
+        /// 1. Calls <see cref="IActivity.CreateReply(string, string)"/> to initialize a response Activity with proper conversation context.
+        /// 2. Adds a newly constructed <see cref="EmailResponse"/> (with the provided HTML body) to the reply's <c>Entities</c>.
+        /// The method does not perform HTML validation or sanitization; callers should ensure the HTML body is safe for downstream rendering.
+        /// </remarks>
+        public static IActivity CreateEmailResponseActivity(this IActivity activity, string emailResponseHtmlBody)
+        {
+            var workingActivity = activity.CreateReply();
+            var emailResponse = new EmailResponse(emailResponseHtmlBody);
+            workingActivity.Entities ??= new List<Entity>();
+            workingActivity.Entities.Add(emailResponse);
+            return workingActivity;
+        }
     }
 }

--- a/src/Notification/Microsoft.Agents.A365.Notifications/Models/EmailResponse.cs
+++ b/src/Notification/Microsoft.Agents.A365.Notifications/Models/EmailResponse.cs
@@ -24,6 +24,36 @@ namespace Microsoft.Agents.A365.Notifications.Models
         {
             HtmlBody = htmlBody;
         }
+
+        /// <summary>
+        /// Creates a new message <see cref="IActivity"/> and attaches an <see cref="EmailResponse"/> entity
+        /// containing the supplied HTML body.
+        /// </summary>
+        /// <param name="emailResponseHtmlBody">The HTML body to embed in the <see cref="EmailResponse"/> entity. May be null or empty.</param>
+        /// <returns>
+        /// A message activity whose <see cref="IActivity.Entities"/> collection includes a single <see cref="EmailResponse"/>
+        /// entity populated with the specified HTML body.
+        /// </returns>
+        /// <remarks>
+        /// The returned activity does not set <see cref="IActivity.Text"/>; consumers are expected to render or process
+        /// the HTML via the attached <see cref="EmailResponse"/> entity. Additional activity properties (e.g. importance,
+        /// locale, attachments) can be set by the caller after creation.
+        /// </remarks>
+        /// <example>
+        /// <code>
+        /// var activity = EmailResponse.CreateEmailResponseActivity("<p>Processed results attached.</p>");
+        /// // Optionally set routing or other metadata:
+        /// activity.Locale = "en-US";
+        /// </code>
+        /// </example>
+        public static IActivity CreateEmailResponseActivity(string emailResponseHtmlBody)
+        {
+            var workingActivity = Activity.CreateMessageActivity();
+            var emailResponse = new EmailResponse(emailResponseHtmlBody);
+            workingActivity.Entities ??= new List<Entity>();
+            workingActivity.Entities.Add(emailResponse);
+            return workingActivity;
+        }
     }
 
 }


### PR DESCRIPTION
Enhanced the `AgentNotification` and `EmailResponse` classes:
- Added `CreateEmailResponseActivity` to `AgentNotification` for creating reply activities with embedded `EmailResponse` entities.
- Introduced a static `CreateEmailResponseActivity` method in `EmailResponse` for generating message activities with HTML body content.
- Included detailed XML documentation for both methods, explaining usage, parameters, and examples.
- Improved extensibility and usability for managing `Activity` objects with `EmailResponse` entities.