### PR TITLE
[Observability][Tooling] Uses context from observability in calls to tools.

### DIFF
--- a/src/Observability/Runtime/Common/TurnContextExtensions.cs
+++ b/src/Observability/Runtime/Common/TurnContextExtensions.cs
@@ -12,22 +12,24 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Common
     /// </summary>
     public static class TurnContextExtensions
     {
-        private static readonly string ChannelIdAgents = "agents";
-        private static readonly string EntityTypeWpxComment = "wpxcomment";
-        private static readonly string EntityTypeEmailNotification = "emailNotification";
-        private static readonly string WpxCommentConversationIdFormat = "{0}_{1}";
-        private static readonly string AgentRole = "agenticUser";
+        private const string ChannelIdAgents = "agents";
+        private const string EntityTypeWpxComment = "wpxcomment";
+        private const string EntityTypeEmailNotification = "emailNotification";
+        private const string WpxCommentConversationIdFormat = "{0}_{1}";
+        private const string AgentRole = "agenticUser";
+        private const string O11ySpanIdKey = "O11ySpanId";
+        private const string O11yTraceIdKey = "O11yTraceId";
 
         /// <summary>
         /// Extracts caller-related baggage key-value pairs from the provided turn context.
         /// </summary>
         public static IEnumerable<KeyValuePair<string, object?>> GetCallerBaggagePairs(this ITurnContext turnContext)
         {
-                yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.GenAiCallerIdKey, turnContext.Activity?.From?.Id);
-                yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.GenAiCallerNameKey, turnContext.Activity?.From?.Name);
-                yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.GenAiCallerUpnKey, turnContext.Activity?.From?.Name);
-                yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.GenAiCallerUserIdKey, turnContext.Activity?.From?.AgenticUserId ?? turnContext.Activity?.From?.AadObjectId);
-                yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.GenAiCallerTenantIdKey, turnContext.Activity?.From?.TenantId);
+            yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.GenAiCallerIdKey, turnContext.Activity?.From?.Id);
+            yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.GenAiCallerNameKey, turnContext.Activity?.From?.Name);
+            yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.GenAiCallerUpnKey, turnContext.Activity?.From?.Name);
+            yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.GenAiCallerUserIdKey, turnContext.Activity?.From?.AgenticUserId ?? turnContext.Activity?.From?.AadObjectId);
+            yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.GenAiCallerTenantIdKey, turnContext.Activity?.From?.TenantId);
         }
 
         /// <summary>
@@ -130,6 +132,15 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Common
             string? itemLink = turnContext?.Activity?.ServiceUrl;
             yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.GenAiConversationIdKey, conversationId);
             yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.GenAiConversationItemLinkKey, itemLink);
+        }
+
+        /// <summary>
+        /// Injects observability context into the turn context.
+        /// </summary>
+        public static void InjectObservabilityContext(this ITurnContext turnContext, OpenTelemetryScope observabilityScope)
+        {
+            turnContext.StackState[O11ySpanIdKey] = observabilityScope.Id;
+            turnContext.StackState[O11yTraceIdKey] = observabilityScope.TraceId;
         }
     }
 }

--- a/src/Observability/Runtime/Tracing/Scopes/OpenTelemetryScope.cs
+++ b/src/Observability/Runtime/Tracing/Scopes/OpenTelemetryScope.cs
@@ -231,5 +231,10 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
         /// Gets the span ID for the current activity.
         /// </summary>
         public string Id => activity?.Id ?? string.Empty;
+
+        /// <summary>
+        /// Gets the trace ID for the current activity.
+        /// </summary>
+        public string TraceId => activity?.TraceId.ToHexString().ToLowerInvariant() ?? string.Empty;
     }
 }

--- a/src/Tooling/Core/Handlers/HttpContextHeadersHandler.cs
+++ b/src/Tooling/Core/Handlers/HttpContextHeadersHandler.cs
@@ -11,18 +11,43 @@ namespace Microsoft.Agents.A365.Tooling.Handlers
 
     internal class HttpContextHeadersHandler(ITurnContext turnContext) : DelegatingHandler
     {
+        // Header names for passing context information in HTTP requests
+        private const string ConversationIdHeader = "x-ms-conversation-id";
+        private const string UserMessageHeader = "x-ms-usermessage";
+        private const string O11ySpanIdHeader = "x-ms-span-id";
+        private const string O11yTraceIdHeader = "x-ms-trace-id";
+
+        // Keys set from Observability
+        private const string O11ySpanIdKey = "O11ySpanId";
+        private const string O11yTraceIdKey = "O11yTraceId";
+
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             if (turnContext?.Activity != null)
             {
                 if (!string.IsNullOrEmpty(turnContext.Activity.Conversation.Id))
                 {
-                    request.Headers.Add("x-ms-conversation-id", turnContext.Activity.Conversation.Id);
+                    request.Headers.Add(ConversationIdHeader, turnContext.Activity.Conversation.Id);
                 }
 
                 if (!string.IsNullOrEmpty(turnContext.Activity.Text))
                 {
-                    request.Headers.Add("x-ms-usermessage", turnContext.Activity.Text);
+                    request.Headers.Add(UserMessageHeader, turnContext.Activity.Text);
+                }
+            }
+
+            if (turnContext != null)
+            {
+                turnContext.StackState.TryGetValue(O11ySpanIdKey, out var spanIdObj);
+                if (spanIdObj is string spanId && !string.IsNullOrEmpty(spanId))
+                {
+                    request.Headers.Add(O11ySpanIdHeader, spanId);
+                }
+
+                turnContext.StackState.TryGetValue(O11yTraceIdKey, out var traceIdObj);
+                if (traceIdObj is string traceId && !string.IsNullOrEmpty(traceId))
+                {
+                    request.Headers.Add(O11yTraceIdHeader, traceId);
                 }
             }
 


### PR DESCRIPTION
We need to pass context from observability to tools so they can be picked up by ATG and used in observability on their service. This will allow us to connect traces from the agent with traces from the tooling gateway.
