### PR TITLE
Remove PackageLicenseUrl from Directory.Build.props

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -33,7 +33,6 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>See CHANGELOG.md for release notes.</PackageReleaseNotes>
     <PackageProjectUrl>https://learn.microsoft.com/microsoft-agent-365/developer</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/microsoft/Agent365-dotnet?tab=MIT-1-ov-file#readme</PackageLicenseUrl>
 
     <!-- Build Configuration -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>


### PR DESCRIPTION
Removed the PackageLicenseUrl element from the build properties.