### PR TITLE
[Observability] Scope and domain overrides

### DIFF
--- a/src/Observability/Runtime/Common/EnvironmentUtils.cs
+++ b/src/Observability/Runtime/Common/EnvironmentUtils.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Common
         /// <returns>The authentication scope.</returns>
         public static string[] GetObservabilityAuthenticationScope()
         {
-            return new[] { ProdObservabilityScope };
+            var overrideScope = Environment.GetEnvironmentVariable("A365_OBSERVABILITY_SCOPE_OVERRIDE");
+            return new[] { !string.IsNullOrEmpty(overrideScope) ? overrideScope : ProdObservabilityScope };
         }
 
         /// <summary>

--- a/src/Observability/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
+++ b/src/Observability/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
@@ -124,8 +124,10 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
                 var json = _formatter.FormatMany(activities, resource);
                 using var content = new StringContent(json, Encoding.UTF8, "application/json");
 
-                var ppapiDiscovery = new PowerPlatformApiDiscovery(options.ClusterCategory);
-                var ppapiEndpoint = ppapiDiscovery.GetTenantIslandClusterEndpoint(tenantId);
+                var ppapiEndpointOverride = Environment.GetEnvironmentVariable("A365_OBSERVABILITY_DOMAIN_OVERRIDE");
+                var ppapiEndpoint = !string.IsNullOrEmpty(ppapiEndpointOverride)
+                    ? ppapiEndpointOverride
+                    : new PowerPlatformApiDiscovery(options.ClusterCategory).GetTenantIslandClusterEndpoint(tenantId);
 
                 var endpointPath = BuildEndpointPath(agentId, options.UseS2SEndpoint);
                 var requestUri = BuildRequestUri(ppapiEndpoint, endpointPath);

--- a/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/Common/EnvironmentUtilsTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/Common/EnvironmentUtilsTests.cs
@@ -1,82 +1,50 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
 using Microsoft.Agents.A365.Observability.Runtime.Common;
-using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Agents.A365.Observability.Runtime.Tests.Common;
 
 [TestClass]
 public class EnvironmentUtilsTests
 {
+    private const string OverrideEnvVarName = "A365_OBSERVABILITY_SCOPE_OVERRIDE";
+
     [TestInitialize]
-    public void TestInit()
+    public void TestInitialize()
     {
-        // Reset initialization before each test by forcing re-initialize with empty configuration
-        var cfg = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>()).Build();
-        EnvironmentUtils.Initialize(cfg, force: true);
+        // Ensure clean environment before each test
+        Environment.SetEnvironmentVariable(OverrideEnvVarName, null);
     }
 
     [TestMethod]
-    public void GetObservabilityAuthenticationScope_DefaultsToProd_WhenNoOverride()
+    public void GetObservabilityAuthenticationScope_ReturnsOverride_WhenEnvVarIsSet()
     {
-        var cfg = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>()).Build();
-        EnvironmentUtils.Initialize(cfg, force: true);
+        // Arrange
+        var expectedOverride = "https://override.example.com/.default";
+        Environment.SetEnvironmentVariable(OverrideEnvVarName, expectedOverride);
 
+        // Act
         var scopes = EnvironmentUtils.GetObservabilityAuthenticationScope();
+
+        // Assert
+        Assert.IsNotNull(scopes);
+        Assert.AreEqual(1, scopes.Length);
+        Assert.AreEqual(expectedOverride, scopes[0]);
+    }
+
+    [TestMethod]
+    public void GetObservabilityAuthenticationScope_ReturnsDefault_WhenEnvVarIsNotSet()
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable(OverrideEnvVarName, null);
+
+        // Act
+        var scopes = EnvironmentUtils.GetObservabilityAuthenticationScope();
+
+        // Assert
+        Assert.IsNotNull(scopes);
         Assert.AreEqual(1, scopes.Length);
         Assert.AreEqual("https://api.powerplatform.com/.default", scopes[0]);
-    }
-
-    [TestMethod]
-    public void GetObservabilityAuthenticationScope_UsesOverride_WhenProvided()
-    {
-        var expected = "https://api.preprod.powerplatform.com/.default";
-        var cfg = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["A365_OBSERVABILITY_SCOPE_OVERRIDE"] = expected,
-            })
-            .Build();
-
-        EnvironmentUtils.Initialize(cfg, force: true);
-
-        var scopes = EnvironmentUtils.GetObservabilityAuthenticationScope();
-        Assert.AreEqual(1, scopes.Length);
-        Assert.AreEqual(expected, scopes[0]);
-    }
-
-    [TestMethod]
-    public void Initialize_WithForce_ReplacesCachedOverride()
-    {
-        var first = "https://first.scope/.default";
-        var second = "https://second.scope/.default";
-
-        var cfg1 = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["A365_OBSERVABILITY_SCOPE_OVERRIDE"] = first,
-            })
-            .Build();
-        EnvironmentUtils.Initialize(cfg1, force: true);
-        var scopes1 = EnvironmentUtils.GetObservabilityAuthenticationScope();
-        Assert.AreEqual(first, scopes1[0]);
-
-        // Without force, override should remain unchanged
-        var cfg2 = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["A365_OBSERVABILITY_SCOPE_OVERRIDE"] = second,
-            })
-            .Build();
-        EnvironmentUtils.Initialize(cfg2, force: false);
-        var scopesNoForce = EnvironmentUtils.GetObservabilityAuthenticationScope();
-        Assert.AreEqual(first, scopesNoForce[0]);
-
-        // With force, value should update
-        EnvironmentUtils.Initialize(cfg2, force: true);
-        var scopes2 = EnvironmentUtils.GetObservabilityAuthenticationScope();
-        Assert.AreEqual(second, scopes2[0]);
     }
 }

--- a/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/Tracing/Exporters/Agent365ExporterTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/Tracing/Exporters/Agent365ExporterTests.cs
@@ -7,6 +7,7 @@ using OpenTelemetry;
 using OpenTelemetry.Resources;
 using System.Diagnostics;
 using System.Reflection;
+using System.Net;
 
 namespace Microsoft.Agents.A365.Observability.Tests.Tracing.Exporters;
 
@@ -1014,4 +1015,67 @@ public sealed class Agent365ExporterTests
     }
 
     #endregion
+
+    [TestMethod]
+    public void Export_RequestUri_UsesDomainOverride_WhenEnvVarSet()
+    {
+        // Arrange
+        var overrideDomain = "override.example.com";
+        Environment.SetEnvironmentVariable("A365_OBSERVABILITY_DOMAIN_OVERRIDE", overrideDomain);
+
+        string? observedUri = null;
+        var handler = new TestHttpMessageHandler(req =>
+        {
+            observedUri = req.RequestUri?.AbsoluteUri;
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+        var httpClient = new HttpClient(handler);
+
+        var options = new Agent365ExporterOptions
+        {
+            TokenResolver = (_, _) => Task.FromResult<string?>("test-token"),
+            UseS2SEndpoint = false
+        };
+
+        var resource = ResourceBuilder.CreateEmpty()
+            .AddService("unit-test-service", serviceVersion: "1.0.0")
+            .Build();
+
+        var exporter = new Agent365Exporter(
+            Agent365ExporterTests._agent365ExporterCore,
+            NullLogger<Agent365Exporter>.Instance,
+            options,
+            resource,
+            httpClient);
+
+        using var activity = CreateActivity(tenantId: "tenant-abc", agentId: "agent-xyz");
+        var batch = CreateBatch(activity);
+
+        // Act
+        var result = exporter.Export(in batch);
+
+        // Assert
+        result.Should().Be(ExportResult.Success);
+        observedUri.Should().NotBeNull();
+        observedUri!.Should().StartWith($"https://{overrideDomain}");
+        observedUri!.Should().Contain($"/maven/agent365/agents/agent-xyz/traces");
+        observedUri!.Should().Contain("api-version=1");
+
+        // Cleanup
+        Environment.SetEnvironmentVariable("A365_OBSERVABILITY_DOMAIN_OVERRIDE", null);
+    }
+
+    private class TestHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+        public TestHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
+        {
+            _handler = handler;
+        }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_handler(request));
+        }
+    }
+
 }


### PR DESCRIPTION
Why? 
To enable 1P testing in pre-prod

What? 
Enable overrides for scope and domain via environment variables "A365_OBSERVABILITY_DOMAIN_OVERRIDE" and "A365_OBSERVABILITY_SCOPE_OVERRIDE".

------

This PR introduces configuration-based overrides for the observability domain and authentication scope to enable testing against pre-production environments. The changes add two new configuration keys (A365_OBSERVABILITY_DOMAIN_OVERRIDE and A365_OBSERVABILITY_SCOPES_OVERRIDE) that allow runtime customization of Power Platform API endpoints and authentication scopes without code changes.

Key Changes
Added EnvironmentUtils.Initialize() method to cache scope override from configuration
Extended PowerPlatformApiDiscovery and Agent365ExporterCore to accept optional domain overrides
Created comprehensive test coverage for both override mechanisms
