### PR TITLE
[Observability] Remove manual scope in SK auto-instrumentation 

### DIFF
--- a/src/Observability/Extensions/SemanticKernel/FunctionInvocationFilter.cs
+++ b/src/Observability/Extensions/SemanticKernel/FunctionInvocationFilter.cs
@@ -36,18 +36,6 @@ public sealed class FunctionInvocationFilter : IFunctionInvocationFilter
             Activity.Current.AddTag(OpenTelemetryConstants.GenAiToolCallIdKey, context.Function.PluginName);
             return;
         }
-        // TODO: figure out how to get agent and tenant details here
-        using var scope = ExecuteToolScope.Start(
-            new ToolCallDetails(
-                context.Function.Name,
-                arguments,
-                null,
-                context.Function.Description,
-                ToolType.Function),
-            new AgentDetails("tempAgentId"),
-            new TenantDetails(new Guid()));
-        await InvokeWithErrorHandlingAsync(next, context);
-        scope?.RecordResponse(GetResult(context));
     }
 
     private async Task InvokeWithErrorHandlingAsync(Func<FunctionInvocationContext, Task> next, FunctionInvocationContext context)


### PR DESCRIPTION
Why?
We conditionally start a manual scope in the function invocation filter with dummy agent and tenant ids. This is not necessary because at this point we should already be withing an execute_tool span started by SK. 

What?
Remove manual scope.

Testing
Using [this ](https://github.com/microsoft/Agent365-Samples/tree/main/dotnet/semantic-kernel)Agent365-Samples sample 

1) Trigger plugin
 
<img width="1140" height="495" alt="image" src="https://github.com/user-attachments/assets/3d7187dd-5815-4ac8-a105-e0f1adf053bb" />

<img width="1811" height="853" alt="image" src="https://github.com/user-attachments/assets/907780ef-5248-42a3-874c-b75c117e72ef" />

2) Function invocation filter is invoked, an execute_tool scope has already been started at the point by the SK SDK
 
<img width="2222" height="417" alt="image" src="https://github.com/user-attachments/assets/3e2e6735-a81e-4338-9f9a-95b138158b5a" />

3) A365 o11y exports this span
 
<img width="1620" height="1051" alt="image" src="https://github.com/user-attachments/assets/30dcdbb8-7ee0-4edf-b535-f035e824ae3b" />
<img width="1517" height="323" alt="image" src="https://github.com/user-attachments/assets/61494d44-729f-4278-9d97-a76c9b3f94d8" />
