### PR TITLE
Correctly read url parameter of ToolingManifest.json when the file is read from disk.

### DIFF
--- a/src/Tooling/Core/Services/McpToolServerConfigurationService.cs
+++ b/src/Tooling/Core/Services/McpToolServerConfigurationService.cs
@@ -236,11 +236,11 @@ namespace Microsoft.Agents.A365.Tooling.Services
             try
             {
                 string? name = null;
+                string? endpoint = null;
                 string? id = null;
                 string? scope = null;
                 string? audience = null;
                 string? publisher = null;
-                string? url = null;
 
                 if (serverElement.TryGetProperty("mcpServerName", out var nameElement) &&
                     nameElement.ValueKind == JsonValueKind.String)
@@ -256,7 +256,7 @@ namespace Microsoft.Agents.A365.Tooling.Services
                 if (serverElement.TryGetProperty("url", out var urlElement) &&
                     urlElement.ValueKind == JsonValueKind.String)
                 {
-                    url = urlElement.GetString();
+                    endpoint = urlElement.GetString();
                 }
 
                 if (serverElement.TryGetProperty("id", out var idElement) &&
@@ -287,7 +287,7 @@ namespace Microsoft.Agents.A365.Tooling.Services
                 }
 
                 // Construct full URL if not provided in manifest
-                var fullUrl = url ?? Utility.BuildMcpServerUrl(name, _configuration);
+                var fullUrl = endpoint ?? Utility.BuildMcpServerUrl(name, _configuration);
 
                 return new MCPServerConfig
                 {


### PR DESCRIPTION
`ParseServerConfigFromManifest` does not currently read the `url` property of the `ToolingManifest.json` file, instead it defaults to a base url that only works for [first-party](https://learn.microsoft.com/en-us/microsoft-agent-365/tooling-servers-overview) Agent 365 tools.

When using the [A365 MCP Management MCP Server](https://learn.microsoft.com/en-us/microsoft-agent-365/mcp-server-reference/mcpmanagement) to create custom MCP Servers, the URL of such a server needs to be configured in the `ToolingManifest.json` file. Example:

```json
{
  "mcpServers": [
    {
      "mcpServerName": "mcp_MailTools",
      "mcpServerUniqueName": "mcp_MailTools"
    }
...
    {
      "mcpServerName": "adde_mycoolmcpserver",
      "mcpServerUniqueName": "adde_mycoolmcpserver",
      "scope": "McpServers.DataverseCustom.All",
      "url": "https://agent365.svc.cloud.microsoft/mcp/environments/f828e740-6703-e4e7-b631-11a48500a013/servers/adde_mycoolmcpserver"
    }
  ]
}
````

This PR fixes this, and also aligns the code in `ParseServerConfigFromManifest` with `ParseServerConfig`. 