### PR TITLE
Email response entity name was incorrectly set as email notification.

### DIFF
--- a/src/Notification/Microsoft.Agents.A365.Notifications/Models/EmailResponse.cs
+++ b/src/Notification/Microsoft.Agents.A365.Notifications/Models/EmailResponse.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Agents.A365.Notifications.Models
     /// <summary>
     /// Represents an email response entity containing HTML body content.
     /// </summary>
-    [EntityName(name:"emailNotification")]
+    [EntityName(name:"emailResponse")]
     public class EmailResponse : Entity
     {
         /// <summary>


### PR DESCRIPTION
This causes deserialization issues on EmailNotification/EmailReference.

Bug:
https://github.com/microsoft/Agent365-dotnet/issues/169

Fixes #169 