### PR TITLE
[Observability] Clean up input and output messages from auto-instrumented invoke_agent spans

### DIFF
--- a/src/Observability/Extensions/SemanticKernel/Models/NestedContent.cs
+++ b/src/Observability/Extensions/SemanticKernel/Models/NestedContent.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Agents.A365.Observability.Extensions.SemanticKernel.Models;
+
+/// <summary>
+/// Represents a nested content structure that may appear within a MessageContent's Content property.
+/// Used when Content is a JSON object with contentType and content fields.
+/// </summary>
+public class NestedContent
+{
+    /// <summary>
+    /// The type of the content (e.g., "Text").
+    /// </summary>
+    [JsonPropertyName("contentType")]
+    public string? ContentType { get; set; }
+
+    /// <summary>
+    /// The actual content value.
+    /// </summary>
+    [JsonPropertyName("content")]
+    public string? Content { get; set; }
+}

--- a/src/Observability/Extensions/SemanticKernel/Utils/SemanticKernelSpanProcessorHelper.cs
+++ b/src/Observability/Extensions/SemanticKernel/Utils/SemanticKernelSpanProcessorHelper.cs
@@ -147,7 +147,7 @@ public static class SemanticKernelSpanProcessorHelper
                     .Where(e => !string.Equals(e.Role, "system", StringComparison.OrdinalIgnoreCase))
                     .Select(e =>
                     {
-                        FilterUserMessageContent(e);
+                        FilterMessageContent(e);
                         return e.Content;
                     })
                     .ToList();
@@ -188,18 +188,61 @@ public static class SemanticKernelSpanProcessorHelper
     }
 
     /// <summary>
-    /// Extracts the message content from user messages by trimming the prefix up to and including 'Message:'.
+    /// Filters and extracts the message content from messages.
+    /// For user messages, trims the prefix up to and including 'Message:'.
+    /// For all messages, if Content is a JSON object with a nested 'content' property, extracts the inner content.
     /// </summary>
     /// <param name="message">The MessageContent to filter.</param>
-    private static void FilterUserMessageContent(MessageContent? message)
+    private static void FilterMessageContent(MessageContent? message)
     {
-        if (message?.Role == "user" && !string.IsNullOrEmpty(message.Content))
+        if (message == null || string.IsNullOrEmpty(message.Content))
+        {
+            return;
+        }
+
+        // Try to extract nested content if Content is a JSON object with a 'content' property
+        TryExtractNestedContent(message);
+
+        // For user messages, trim the "Message:" prefix
+        if (string.Equals(message.Role, "user", StringComparison.OrdinalIgnoreCase))
         {
             var idx = message.Content.IndexOf("Message:", StringComparison.OrdinalIgnoreCase);
             if (idx >= 0)
             {
                 message.Content = message.Content[(idx + "Message:".Length)..].Trim();
             }
+        }
+    }
+
+    /// <summary>
+    /// Attempts to extract nested content from a message's Content property.
+    /// If Content is a JSON object with a 'content' property, replaces Content with the inner content value.
+    /// </summary>
+    /// <param name="message">The MessageContent to process.</param>
+    private static void TryExtractNestedContent(MessageContent message)
+    {
+        if (string.IsNullOrEmpty(message.Content))
+        {
+            return;
+        }
+
+        var content = message.Content.Trim();
+        if (!content.StartsWith("{", StringComparison.Ordinal) || !content.EndsWith("}", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        try
+        {
+            var nestedContent = JsonSerializer.Deserialize<NestedContent>(content, JsonOptions);
+            if (nestedContent?.Content != null)
+            {
+                message.Content = nestedContent.Content;
+            }
+        }
+        catch (JsonException)
+        {
+            // Content is not a valid nested content JSON, keep the original value
         }
     }
 
@@ -232,7 +275,7 @@ public static class SemanticKernelSpanProcessorHelper
                     var userMsg = JsonSerializer.Deserialize<MessageContent>(content, JsonOptions);
                     if (userMsg != null && userMsg.Role == "user" && !string.IsNullOrEmpty(userMsg.Content))
                     {
-                        FilterUserMessageContent(userMsg);
+                        FilterMessageContent(userMsg);
                         result[OpenTelemetryConstants.GenAiUserMessageEventName].Add(userMsg.Content);
                     }
                 }

--- a/src/Tests/Microsoft.Agents.A365.Observability.Extension.Tests/SemanticKernelSpanProcessorHelperTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Extension.Tests/SemanticKernelSpanProcessorHelperTests.cs
@@ -176,5 +176,61 @@ namespace Microsoft.Agents.A365.Observability.Extension.Tests
             Assert.AreEqual(1, choiceMessages.Count);
             Assert.AreEqual("not a json", choiceMessages[0]);
         }
+
+        [TestMethod]
+        public void ProcessInvocationInputOutputTag_ExtractsNestedContentFromAssistantMessages()
+        {
+            var activity = new Activity("test");
+
+            // JSON array with an assistant message containing nested content structure
+            var nestedContentJson = @"{""contentType"": ""'Text'"", ""content"": ""Hello! Before I can assist you, you must accept the terms and conditions.""}";
+            var jsonArrayOfObjects = $@"[{{""role"":""Assistant"",""name"":""Agent365Agent"",""content"":{JsonSerializer.Serialize(nestedContentJson)}}}]";
+
+            activity.SetTag(OpenTelemetryConstants.GenAiAgentInvocationOutputKey, jsonArrayOfObjects);
+
+            SemanticKernelSpanProcessorHelper.ProcessInvocationInputOutputTag(activity);
+
+            var filtered = activity.Tags.FirstOrDefault(t => t.Key == OpenTelemetryConstants.GenAiAgentInvocationOutputKey).Value as string;
+            Assert.IsNotNull(filtered);
+            Assert.IsTrue(filtered.Contains("Hello! Before I can assist you, you must accept the terms and conditions."), "Nested content should be extracted");
+            Assert.IsFalse(filtered.Contains("contentType"), "contentType property should be removed");
+        }
+
+        [TestMethod]
+        public void ProcessInvocationInputOutputTag_PreservesNonNestedContent()
+        {
+            var activity = new Activity("test");
+
+            // JSON array with a user message that has simple string content (not nested)
+            var jsonArrayOfObjects = @"[{""role"":""user"",""name"":null,""content"":""Message:Simple text message""}]";
+
+            activity.SetTag(OpenTelemetryConstants.GenAiAgentInvocationInputKey, jsonArrayOfObjects);
+
+            SemanticKernelSpanProcessorHelper.ProcessInvocationInputOutputTag(activity);
+
+            var filtered = activity.Tags.FirstOrDefault(t => t.Key == OpenTelemetryConstants.GenAiAgentInvocationInputKey).Value as string;
+            Assert.IsNotNull(filtered);
+            Assert.IsTrue(filtered.Contains("Simple text message"), "Simple content should be preserved after Message: trimming");
+        }
+
+        [TestMethod]
+        public void ProcessInvocationInputOutputTag_HandlesNestedContentWithUserRole()
+        {
+            var activity = new Activity("test");
+
+            // JSON array with a user message containing nested content structure AND Message: prefix
+            var nestedContentJson = @"{""contentType"": ""'Text'"", ""content"": ""Message:User query with nested structure""}";
+            var jsonArrayOfObjects = $@"[{{""role"":""user"",""name"":null,""content"":{JsonSerializer.Serialize(nestedContentJson)}}}]";
+
+            activity.SetTag(OpenTelemetryConstants.GenAiAgentInvocationInputKey, jsonArrayOfObjects);
+
+            SemanticKernelSpanProcessorHelper.ProcessInvocationInputOutputTag(activity);
+
+            var filtered = activity.Tags.FirstOrDefault(t => t.Key == OpenTelemetryConstants.GenAiAgentInvocationInputKey).Value as string;
+            Assert.IsNotNull(filtered);
+            Assert.IsTrue(filtered.Contains("User query with nested structure"), "Nested content should be extracted and Message: prefix trimmed");
+            Assert.IsFalse(filtered.Contains("contentType"), "contentType property should be removed");
+            Assert.IsFalse(filtered.Contains("Message:"), "Message: prefix should be trimmed");
+        }
     }
 }


### PR DESCRIPTION
**Why?**
Existing clean up logic does not work as expected because:
It attempts to cleanup invocation_input and invocation_output attributes, but for invoke_agent spans SK uses input_messages and output_messages
Deserialization fails because it expects a list of strings but actually it is a list of objects of type `MessageContent`.

**What?**
Try to filter input_messages and output_messages attributes in addition to existing. 
First try to deserialize into a list of objects.

**Testing**

Without fix
<img width="1921" height="591" alt="image" src="https://github.com/user-attachments/assets/b99c06fa-e5fe-4395-9a92-05765c870401" />

Zooming in on input_messages and output_messages
<img width="2490" height="308" alt="image" src="https://github.com/user-attachments/assets/6c7804e3-970b-4b73-abe5-3aea81beb7e9" />
<img width="2455" height="276" alt="image" src="https://github.com/user-attachments/assets/9cc2bb51-df82-4b56-bf3b-9e6cb6f58eba" />

With fix
<img width="2782" height="503" alt="image" src="https://github.com/user-attachments/assets/839ee62a-5c65-43c0-aa2c-06e0cc129c42" />




