### PR TITLE
[Observability] Do not set target agent/caller UPN attribute when using turn context

### DIFF
--- a/src/Observability/Hosting/Extensions/TurnContextExtensions.cs
+++ b/src/Observability/Hosting/Extensions/TurnContextExtensions.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Agents.A365.Observability.Hosting.Extensions
         {
             yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.GenAiCallerIdKey, turnContext.Activity?.From?.Id);
             yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.GenAiCallerNameKey, turnContext.Activity?.From?.Name);
-            yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.GenAiCallerUpnKey, turnContext.Activity?.From?.AgenticUserId);
             yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.GenAiCallerTenantIdKey, turnContext.Activity?.From?.TenantId);
         }
 
@@ -50,7 +49,6 @@ namespace Microsoft.Agents.A365.Observability.Hosting.Extensions
             yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.GenAiAgentIdKey, turnContext.Activity?.Recipient?.AgenticAppId ?? turnContext.Activity?.Recipient?.Id);
             yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.GenAiAgentNameKey, turnContext.Activity?.Recipient?.Name);
             yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.GenAiAgentAUIDKey, turnContext.Activity?.Recipient?.AgenticUserId ?? turnContext.Activity?.Recipient?.AadObjectId);
-            yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.GenAiAgentUPNKey, turnContext.Activity?.Recipient?.AgenticUserId);
             yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.GenAiAgentDescriptionKey, turnContext.Activity?.Recipient?.Role);
         }
 


### PR DESCRIPTION
**Why?**
Today we set the caller and agent UPN attribute values to the "Name" from turnContext. This is not a UPN. These fields have specific downstream uses. Not setting a valid UPN breaks them. 

<img width="2024" height="835" alt="image" src="https://github.com/user-attachments/assets/0854a008-6edf-46b9-81a5-81e30f08d72d" />

**What?**
Just dont set the value of UPN. This way it can be identified as a missing attributes during certification, and the agent developer can get it via a graph call or any other mechanism and set it to a valid value.