### PR TITLE
SK and Agent SDK to use new message format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ jobs:
 
       - name: Run tests
         run: dotnet test Microsoft.Agents.A365.Sdk.sln --no-build --configuration Release --verbosity normal
+        env:
+          AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          AZURE_OPENAI_DEPLOYMENT: ${{ secrets.AZURE_OPENAI_DEPLOYMENT }}
 
       - name: Pack
         run: dotnet pack Microsoft.Agents.A365.Sdk.sln --no-build --configuration Release --output ../NuGetPackages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,9 @@ jobs:
       - name: Run tests
         run: dotnet test Microsoft.Agents.A365.Sdk.sln --no-build --configuration Release --verbosity normal
         env:
-          AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          AZURE_OPENAI_ENDPOINT: ${{ vars.AZURE_OPENAI_ENDPOINT }}
           AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
-          AZURE_OPENAI_DEPLOYMENT: ${{ secrets.AZURE_OPENAI_DEPLOYMENT }}
+          AZURE_OPENAI_DEPLOYMENT: ${{ vars.AZURE_OPENAI_DEPLOYMENT }}
 
       - name: Pack
         run: dotnet pack Microsoft.Agents.A365.Sdk.sln --no-build --configuration Release --output ../NuGetPackages

--- a/src/Microsoft.Agents.A365.Sdk.sln
+++ b/src/Microsoft.Agents.A365.Sdk.sln
@@ -90,6 +90,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Core", "Core", "{0CBC637E-E
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Agents.A365.Tooling.Core.Tests", "Tests\Microsoft.Agents.A365.Tooling.Core.Tests\Microsoft.Agents.A365.Tooling.Core.Tests.csproj", "{5322E121-710E-4CBD-A5C4-0AC9E85F7164}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Agents.A365.Observability.Extensions.IntegrationTests", "Tests\Microsoft.Agents.A365.Observability.Extensions.IntegrationTests\Microsoft.Agents.A365.Observability.Extensions.IntegrationTests.csproj", "{260338F1-ABA4-4617-81F3-B84AAEA43D52}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -364,6 +366,18 @@ Global
 		{5322E121-710E-4CBD-A5C4-0AC9E85F7164}.Release|x64.Build.0 = Release|Any CPU
 		{5322E121-710E-4CBD-A5C4-0AC9E85F7164}.Release|x86.ActiveCfg = Release|Any CPU
 		{5322E121-710E-4CBD-A5C4-0AC9E85F7164}.Release|x86.Build.0 = Release|Any CPU
+		{260338F1-ABA4-4617-81F3-B84AAEA43D52}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{260338F1-ABA4-4617-81F3-B84AAEA43D52}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{260338F1-ABA4-4617-81F3-B84AAEA43D52}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{260338F1-ABA4-4617-81F3-B84AAEA43D52}.Debug|x64.Build.0 = Debug|Any CPU
+		{260338F1-ABA4-4617-81F3-B84AAEA43D52}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{260338F1-ABA4-4617-81F3-B84AAEA43D52}.Debug|x86.Build.0 = Debug|Any CPU
+		{260338F1-ABA4-4617-81F3-B84AAEA43D52}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{260338F1-ABA4-4617-81F3-B84AAEA43D52}.Release|Any CPU.Build.0 = Release|Any CPU
+		{260338F1-ABA4-4617-81F3-B84AAEA43D52}.Release|x64.ActiveCfg = Release|Any CPU
+		{260338F1-ABA4-4617-81F3-B84AAEA43D52}.Release|x64.Build.0 = Release|Any CPU
+		{260338F1-ABA4-4617-81F3-B84AAEA43D52}.Release|x86.ActiveCfg = Release|Any CPU
+		{260338F1-ABA4-4617-81F3-B84AAEA43D52}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -402,6 +416,7 @@ Global
 		{A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D} = {2150E333-8FDC-42A3-9474-1A3956D46DE8}
 		{0CBC637E-EC70-66CD-FE99-EB46F5448A6D} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{5322E121-710E-4CBD-A5C4-0AC9E85F7164} = {2150E333-8FDC-42A3-9474-1A3956D46DE8}
+		{260338F1-ABA4-4617-81F3-B84AAEA43D52} = {2150E333-8FDC-42A3-9474-1A3956D46DE8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0B20062E-2453-4E32-B8A2-85A6013F83A0}

--- a/src/Observability/Extensions/AgentFramework/AgentFrameworkSpanProcessor.cs
+++ b/src/Observability/Extensions/AgentFramework/AgentFrameworkSpanProcessor.cs
@@ -39,7 +39,17 @@ namespace Microsoft.Agents.A365.Observability.Extensions.AgentFramework
                     {
                         case InvokeAgentOperation:
                         case ChatOperation:
-                            AgentFrameworkSpanProcessorHelper.ProcessInputOutputMessages(activity);
+                            var inputMessages = AgentFrameworkMessageMapper.MapInputMessages(activity);
+                            if (inputMessages != null)
+                            {
+                                activity.SetTag(OpenTelemetryConstants.GenAiInputMessagesKey, inputMessages);
+                            }
+
+                            var outputMessages = AgentFrameworkMessageMapper.MapOutputMessages(activity);
+                            if (outputMessages != null)
+                            {
+                                activity.SetTag(OpenTelemetryConstants.GenAiOutputMessagesKey, outputMessages);
+                            }
                             break;
 
                         case ExecuteToolOperation:

--- a/src/Observability/Extensions/AgentFramework/Microsoft.Agents.A365.Observability.Extensions.AgentFramework.csproj
+++ b/src/Observability/Extensions/AgentFramework/Microsoft.Agents.A365.Observability.Extensions.AgentFramework.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.Agents.A365.Observability.Extension.Tests" />
+    <InternalsVisibleTo Include="Microsoft.Agents.A365.Observability.Extensions.IntegrationTests" />
   </ItemGroup>
     
   <ItemGroup>

--- a/src/Observability/Extensions/AgentFramework/Utils/AgentFrameworkMessageMapper.cs
+++ b/src/Observability/Extensions/AgentFramework/Utils/AgentFrameworkMessageMapper.cs
@@ -1,0 +1,309 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Agents.A365.Observability.Extensions.AgentFramework.Utils;
+
+using Microsoft.Agents.A365.Observability.Runtime.Tracing;
+using Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.Messages;
+using Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text.Json;
+
+/// <summary>
+/// Maps Agent Framework span tag messages to A365 versioned message format.
+/// Agent Framework sets <c>gen_ai.input.messages</c> / <c>gen_ai.output.messages</c> as span tags
+/// containing JSON arrays of <c>{role, parts[{type, content}], finish_reason?}</c>.
+/// This mapper converts them to <see cref="InputMessages"/> / <see cref="OutputMessages"/>.
+/// </summary>
+internal static class AgentFrameworkMessageMapper
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    /// <summary>
+    /// Maps the <c>gen_ai.input.messages</c> tag value to a serialized A365 <see cref="InputMessages"/> JSON string.
+    /// </summary>
+    public static string? MapInputMessages(Activity activity)
+    {
+        var json = GetTagValue(activity, OpenTelemetryConstants.GenAiInputMessagesKey);
+        if (string.IsNullOrEmpty(json))
+            return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.ValueKind != JsonValueKind.Array)
+                return null;
+
+            var chatMessages = new List<ChatMessage>();
+
+            foreach (var msgElement in doc.RootElement.EnumerateArray())
+            {
+                var role = GetStringProperty(msgElement, "role");
+                var mappedRole = MapRole(role);
+                var parts = MapParts(msgElement);
+                var name = GetStringProperty(msgElement, "name");
+
+                if (parts.Count > 0)
+                {
+                    chatMessages.Add(new ChatMessage(mappedRole, parts, name));
+                }
+            }
+
+            if (chatMessages.Count == 0)
+                return null;
+
+            return MessageUtils.Serialize(new InputMessages(chatMessages));
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Maps the <c>gen_ai.output.messages</c> tag value to a serialized A365 <see cref="OutputMessages"/> JSON string.
+    /// </summary>
+    public static string? MapOutputMessages(Activity activity)
+    {
+        var json = GetTagValue(activity, OpenTelemetryConstants.GenAiOutputMessagesKey);
+        if (string.IsNullOrEmpty(json))
+            return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.ValueKind != JsonValueKind.Array)
+                return null;
+
+            var outputMessages = new List<OutputMessage>();
+
+            foreach (var msgElement in doc.RootElement.EnumerateArray())
+            {
+                var role = MapRole(GetStringProperty(msgElement, "role"));
+                var parts = MapParts(msgElement);
+                var finishReason = GetStringProperty(msgElement, "finish_reason");
+
+                if (parts.Count > 0)
+                {
+                    outputMessages.Add(new OutputMessage(role, parts, finishReason: finishReason));
+                }
+            }
+
+            if (outputMessages.Count == 0)
+                return null;
+
+            return MessageUtils.Serialize(new OutputMessages(outputMessages));
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static List<IMessagePart> MapParts(JsonElement msgElement)
+    {
+        var parts = new List<IMessagePart>();
+
+        if (!msgElement.TryGetProperty("parts", out var partsElement) ||
+            partsElement.ValueKind != JsonValueKind.Array)
+        {
+            return parts;
+        }
+
+        foreach (var partElement in partsElement.EnumerateArray())
+        {
+            var partType = GetStringProperty(partElement, "type");
+            if (string.IsNullOrEmpty(partType))
+                continue;
+
+            var part = MapSinglePart(partType, partElement);
+            if (part != null)
+            {
+                parts.Add(part);
+            }
+        }
+
+        return parts;
+    }
+
+    private static IMessagePart? MapSinglePart(string partType, JsonElement partElement)
+    {
+        switch (partType.ToLowerInvariant())
+        {
+            case "text":
+                var textContent = GetStringProperty(partElement, "content");
+                return !string.IsNullOrEmpty(textContent) ? new TextPart(textContent) : null;
+
+            case "reasoning":
+                var reasoningContent = GetStringProperty(partElement, "content");
+                return !string.IsNullOrEmpty(reasoningContent) ? new ReasoningPart(reasoningContent) : null;
+
+            case "tool_call":
+                return MapToolCallPart(partElement);
+
+            case "tool_call_response":
+                return MapToolCallResponsePart(partElement);
+
+            case "blob":
+                return MapBlobPart(partElement);
+
+            case "file":
+                return MapFilePart(partElement);
+
+            case "uri":
+                return MapUriPart(partElement);
+
+            case "server_tool_call":
+                return MapServerToolCallPart(partElement);
+
+            case "server_tool_call_response":
+                return MapServerToolCallResponsePart(partElement);
+
+            default:
+                return MapGenericPart(partType, partElement);
+        }
+    }
+
+    private static IMessagePart? MapToolCallPart(JsonElement el)
+    {
+        var name = GetStringProperty(el, "name");
+        if (string.IsNullOrEmpty(name))
+            return null;
+
+        var id = GetStringProperty(el, "id");
+        object? arguments = null;
+        if (el.TryGetProperty("arguments", out var argsEl))
+        {
+            arguments = argsEl.ValueKind == JsonValueKind.String
+                ? argsEl.GetString()
+                : argsEl.ToString();
+        }
+
+        return new ToolCallRequestPart(name, id, arguments);
+    }
+
+    private static IMessagePart? MapToolCallResponsePart(JsonElement el)
+    {
+        var id = GetStringProperty(el, "id");
+        object? response = null;
+        if (el.TryGetProperty("response", out var respEl))
+        {
+            response = respEl.ValueKind == JsonValueKind.String
+                ? respEl.GetString()
+                : respEl.ToString();
+        }
+
+        return new ToolCallResponsePart(id, response);
+    }
+
+    private static IMessagePart? MapBlobPart(JsonElement el)
+    {
+        var modality = GetStringProperty(el, "modality");
+        var content = GetStringProperty(el, "content");
+        if (string.IsNullOrEmpty(modality) || string.IsNullOrEmpty(content))
+            return null;
+
+        var mimeType = GetStringProperty(el, "mime_type");
+        return new BlobPart(modality, content, mimeType);
+    }
+
+    private static IMessagePart? MapFilePart(JsonElement el)
+    {
+        var modality = GetStringProperty(el, "modality");
+        var fileId = GetStringProperty(el, "file_id");
+        if (string.IsNullOrEmpty(modality) || string.IsNullOrEmpty(fileId))
+            return null;
+
+        var mimeType = GetStringProperty(el, "mime_type");
+        return new FilePart(modality, fileId, mimeType);
+    }
+
+    private static IMessagePart? MapUriPart(JsonElement el)
+    {
+        var modality = GetStringProperty(el, "modality");
+        var uri = GetStringProperty(el, "uri");
+        if (string.IsNullOrEmpty(modality) || string.IsNullOrEmpty(uri))
+            return null;
+
+        var mimeType = GetStringProperty(el, "mime_type");
+        return new UriPart(modality, uri, mimeType);
+    }
+
+    private static IMessagePart? MapServerToolCallPart(JsonElement el)
+    {
+        var name = GetStringProperty(el, "name");
+        if (string.IsNullOrEmpty(name))
+            return null;
+
+        var id = GetStringProperty(el, "id");
+        var payload = new Dictionary<string, object>();
+        if (el.TryGetProperty("server_tool_call", out var stcEl))
+        {
+            payload["server_tool_call"] = stcEl.ToString();
+        }
+
+        return new ServerToolCallPart(name, payload, id);
+    }
+
+    private static IMessagePart? MapServerToolCallResponsePart(JsonElement el)
+    {
+        var id = GetStringProperty(el, "id");
+        var payload = new Dictionary<string, object>();
+        if (el.TryGetProperty("server_tool_call_response", out var strEl))
+        {
+            payload["server_tool_call_response"] = strEl.ToString();
+        }
+
+        return new ServerToolCallResponsePart(payload, id);
+    }
+
+    private static IMessagePart? MapGenericPart(string type, JsonElement el)
+    {
+        var data = new Dictionary<string, object>();
+        foreach (var prop in el.EnumerateObject())
+        {
+            if (prop.Name != "type")
+            {
+                data[prop.Name] = prop.Value.ValueKind == JsonValueKind.String
+                    ? prop.Value.GetString()!
+                    : prop.Value.ToString();
+            }
+        }
+
+        return new GenericPart(type, data);
+    }
+
+    private static MessageRole MapRole(string? role)
+    {
+        if (string.IsNullOrEmpty(role))
+            return MessageRole.User;
+
+        if (role.Equals("system", StringComparison.OrdinalIgnoreCase)) return MessageRole.System;
+        if (role.Equals("user", StringComparison.OrdinalIgnoreCase)) return MessageRole.User;
+        if (role.Equals("assistant", StringComparison.OrdinalIgnoreCase)) return MessageRole.Assistant;
+        if (role.Equals("tool", StringComparison.OrdinalIgnoreCase)) return MessageRole.Tool;
+
+        return MessageRole.User;
+    }
+
+    private static string? GetTagValue(Activity activity, string key)
+    {
+        return activity.TagObjects
+            .OfType<KeyValuePair<string, object>>()
+            .FirstOrDefault(k => k.Key == key).Value as string;
+    }
+
+    private static string? GetStringProperty(JsonElement element, string propertyName)
+    {
+        if (element.TryGetProperty(propertyName, out var prop) && prop.ValueKind == JsonValueKind.String)
+            return prop.GetString();
+        return null;
+    }
+}

--- a/src/Observability/Extensions/AgentFramework/Utils/AgentFrameworkMessageMapper.cs
+++ b/src/Observability/Extensions/AgentFramework/Utils/AgentFrameworkMessageMapper.cs
@@ -20,11 +20,6 @@ using System.Text.Json;
 /// </summary>
 internal static class AgentFrameworkMessageMapper
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        WriteIndented = false
-    };
 
     /// <summary>
     /// Maps the <c>gen_ai.input.messages</c> tag value to a serialized A365 <see cref="InputMessages"/> JSON string.

--- a/src/Observability/Extensions/AgentFramework/Utils/AgentFrameworkMessageMapper.cs
+++ b/src/Observability/Extensions/AgentFramework/Utils/AgentFrameworkMessageMapper.cs
@@ -9,7 +9,6 @@ using Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Text.Json;
 
 /// <summary>
@@ -290,9 +289,7 @@ internal static class AgentFrameworkMessageMapper
 
     private static string? GetTagValue(Activity activity, string key)
     {
-        return activity.TagObjects
-            .OfType<KeyValuePair<string, object>>()
-            .FirstOrDefault(k => k.Key == key).Value as string;
+        return activity.GetTagItem(key) as string;
     }
 
     private static string? GetStringProperty(JsonElement element, string propertyName)

--- a/src/Observability/Extensions/AgentFramework/Utils/AgentFrameworkMessageMapper.cs
+++ b/src/Observability/Extensions/AgentFramework/Utils/AgentFrameworkMessageMapper.cs
@@ -40,7 +40,7 @@ internal static class AgentFrameworkMessageMapper
             foreach (var msgElement in doc.RootElement.EnumerateArray())
             {
                 var role = GetStringProperty(msgElement, "role");
-                var mappedRole = MapRole(role);
+                var mappedRole = MapRole(role, MessageRole.User);
                 var parts = MapParts(msgElement);
                 var name = GetStringProperty(msgElement, "name");
 
@@ -80,7 +80,7 @@ internal static class AgentFrameworkMessageMapper
 
             foreach (var msgElement in doc.RootElement.EnumerateArray())
             {
-                var role = MapRole(GetStringProperty(msgElement, "role"));
+                var role = MapRole(GetStringProperty(msgElement, "role"), MessageRole.Assistant);
                 var parts = MapParts(msgElement);
                 var finishReason = GetStringProperty(msgElement, "finish_reason");
 
@@ -274,17 +274,17 @@ internal static class AgentFrameworkMessageMapper
         return new GenericPart(type, data);
     }
 
-    private static MessageRole MapRole(string? role)
+    private static MessageRole MapRole(string? role, MessageRole defaultRole)
     {
         if (string.IsNullOrEmpty(role))
-            return MessageRole.User;
+            return defaultRole;
 
         if (role.Equals("system", StringComparison.OrdinalIgnoreCase)) return MessageRole.System;
         if (role.Equals("user", StringComparison.OrdinalIgnoreCase)) return MessageRole.User;
         if (role.Equals("assistant", StringComparison.OrdinalIgnoreCase)) return MessageRole.Assistant;
         if (role.Equals("tool", StringComparison.OrdinalIgnoreCase)) return MessageRole.Tool;
 
-        return MessageRole.User;
+        return defaultRole;
     }
 
     private static string? GetTagValue(Activity activity, string key)

--- a/src/Observability/Extensions/OpenAI/Microsoft.Agents.A365.Observability.Extensions.OpenAI.csproj
+++ b/src/Observability/Extensions/OpenAI/Microsoft.Agents.A365.Observability.Extensions.OpenAI.csproj
@@ -12,6 +12,9 @@
     <PackageTags>Microsoft;Agents;A365;Observability;OpenAI;OpenTelemetry;AI;Agents;Tracing;Monitoring</PackageTags>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.Agents.A365.Observability.Extensions.IntegrationTests" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Observability/Extensions/SemanticKernel/Microsoft.Agents.A365.Observability.Extensions.SemanticKernel.csproj
+++ b/src/Observability/Extensions/SemanticKernel/Microsoft.Agents.A365.Observability.Extensions.SemanticKernel.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.Agents.A365.Observability.Extension.Tests" />
+    <InternalsVisibleTo Include="Microsoft.Agents.A365.Observability.Extensions.IntegrationTests" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SemanticKernel" />

--- a/src/Observability/Extensions/SemanticKernel/SemanticKernelSpanProcessor.cs
+++ b/src/Observability/Extensions/SemanticKernel/SemanticKernelSpanProcessor.cs
@@ -10,7 +10,6 @@ using Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes;
 using Microsoft.Extensions.Configuration;
 using OpenTelemetry;
 using System.Diagnostics;
-using System.Linq;
 
 internal class SemanticKernelSpanProcessor : BaseProcessor<Activity>
 {
@@ -34,8 +33,8 @@ internal class SemanticKernelSpanProcessor : BaseProcessor<Activity>
     {
         if (activity.Source.Name.StartsWith(TargetSourceName))
         {
-            var tags = activity.Tags.ToDictionary(kv => kv.Key, kv => kv.Value);
-            if (tags.TryGetValue(OpenTelemetryConstants.GenAiOperationNameKey, out var operationName))
+            var operationName = activity.GetTagItem(OpenTelemetryConstants.GenAiOperationNameKey) as string;
+            if (operationName != null)
             {
                 switch (operationName)
                 {

--- a/src/Observability/Extensions/SemanticKernel/SemanticKernelSpanProcessor.cs
+++ b/src/Observability/Extensions/SemanticKernel/SemanticKernelSpanProcessor.cs
@@ -56,18 +56,17 @@ internal class SemanticKernelSpanProcessor : BaseProcessor<Activity>
                             .Replace(SemanticKernelTelemetryConstants.ChatCompletionsOperation, InferenceOperationType.Chat.ToString())
                             .Replace(SemanticKernelTelemetryConstants.ChatOperation, InferenceOperationType.Chat.ToString());
 
-                        var userAndChoiceMessages = SemanticKernelSpanProcessorHelper.GetGenAiUserAndChoiceMessageContent(activity);
-                        if (userAndChoiceMessages.TryGetValue(OpenTelemetryConstants.GenAiUserMessageEventName, out var userObj) &&
-                            userObj is List<string> userMessages && userMessages.Count > 0)
+                        var inputMessages = SemanticKernelMessageMapper.MapInputMessages(activity);
+                        if (inputMessages != null)
                         {
-                            activity.SetTag(OpenTelemetryConstants.GenAiInputMessagesKey, string.Join(", ", userMessages));
+                            activity.SetTag(OpenTelemetryConstants.GenAiInputMessagesKey, inputMessages);
                         }
-                        if (userAndChoiceMessages.TryGetValue(OpenTelemetryConstants.GenAiChoiceEventName, out var choiceObj) &&
-                            choiceObj is List<string> choiceMessages && choiceMessages.Count > 0)
+
+                        var outputMessages = SemanticKernelMessageMapper.MapOutputMessages(activity);
+                        if (outputMessages != null)
                         {
-                            activity.SetTag(OpenTelemetryConstants.GenAiOutputMessagesKey, string.Join(", ", choiceMessages));
+                            activity.SetTag(OpenTelemetryConstants.GenAiOutputMessagesKey, outputMessages);
                         }
-                        // Other tags set by SK SDK follow Microsoft Agent 365 schema.
                         break;
                 }
             }

--- a/src/Observability/Extensions/SemanticKernel/Utils/SemanticKernelMessageMapper.cs
+++ b/src/Observability/Extensions/SemanticKernel/Utils/SemanticKernelMessageMapper.cs
@@ -8,7 +8,6 @@ using Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.Messages;
 using Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Text.Json;
 
 /// <summary>
@@ -285,8 +284,16 @@ internal static class SemanticKernelMessageMapper
 
     private static string? GetEventContentTag(ActivityEvent activityEvent)
     {
-        return activityEvent.Tags?
-            .FirstOrDefault(tag => tag.Key == SemanticKernelTelemetryConstants.EventContentTag).Value as string;
+        if (activityEvent.Tags == null)
+            return null;
+
+        foreach (var tag in activityEvent.Tags)
+        {
+            if (tag.Key == SemanticKernelTelemetryConstants.EventContentTag)
+                return tag.Value as string;
+        }
+
+        return null;
     }
 
     private static string? GetStringProperty(JsonElement element, string propertyName)

--- a/src/Observability/Extensions/SemanticKernel/Utils/SemanticKernelMessageMapper.cs
+++ b/src/Observability/Extensions/SemanticKernel/Utils/SemanticKernelMessageMapper.cs
@@ -248,7 +248,7 @@ internal static class SemanticKernelMessageMapper
             if (parts.Count == 0)
                 return;
 
-            var role = MapRole(GetStringProperty(msgElement, "role"));
+            var role = MapRole(GetStringProperty(msgElement, "role"), MessageRole.Assistant);
             var finishReason = MapFinishReason(GetStringProperty(root, "finish_reason"));
 
             messages.Add(new OutputMessage(role, parts, finishReason: finishReason));
@@ -256,17 +256,17 @@ internal static class SemanticKernelMessageMapper
         catch (JsonException) { }
     }
 
-    private static MessageRole MapRole(string? role)
+    private static MessageRole MapRole(string? role, MessageRole defaultRole)
     {
         if (string.IsNullOrEmpty(role))
-            return MessageRole.Assistant;
+            return defaultRole;
 
         if (role.Equals("system", System.StringComparison.OrdinalIgnoreCase)) return MessageRole.System;
         if (role.Equals("user", System.StringComparison.OrdinalIgnoreCase)) return MessageRole.User;
         if (role.Equals("assistant", System.StringComparison.OrdinalIgnoreCase)) return MessageRole.Assistant;
         if (role.Equals("tool", System.StringComparison.OrdinalIgnoreCase)) return MessageRole.Tool;
 
-        return MessageRole.Assistant;
+        return defaultRole;
     }
 
     private static string? MapFinishReason(string? skFinishReason)

--- a/src/Observability/Extensions/SemanticKernel/Utils/SemanticKernelMessageMapper.cs
+++ b/src/Observability/Extensions/SemanticKernel/Utils/SemanticKernelMessageMapper.cs
@@ -34,7 +34,6 @@ internal static class SemanticKernelMessageMapper
             return null;
 
         var chatMessages = new List<ChatMessage>();
-        string? lastAssistantToolCallId = null;
 
         foreach (var ev in activity.Events)
         {
@@ -54,12 +53,11 @@ internal static class SemanticKernelMessageMapper
                     break;
 
                 case "gen_ai.assistant.message":
-                    lastAssistantToolCallId = MapAssistantMessage(content, chatMessages);
+                    MapAssistantMessage(content, chatMessages);
                     break;
 
                 case "gen_ai.tool.message":
-                    MapToolMessage(content, chatMessages, lastAssistantToolCallId);
-                    lastAssistantToolCallId = null;
+                    MapToolMessage(content, chatMessages);
                     break;
             }
         }
@@ -135,16 +133,15 @@ internal static class SemanticKernelMessageMapper
     }
 
     /// <summary>
-    /// Maps an assistant message. Returns the first tool call ID if present (for correlating tool responses).
+    /// Maps an assistant message with optional tool calls.
     /// </summary>
-    private static string? MapAssistantMessage(string json, List<ChatMessage> messages)
+    private static void MapAssistantMessage(string json, List<ChatMessage> messages)
     {
         try
         {
             using var doc = JsonDocument.Parse(json);
             var root = doc.RootElement;
             var parts = new List<IMessagePart>();
-            string? firstToolCallId = null;
 
             var textContent = GetStringProperty(root, "content");
             if (!string.IsNullOrEmpty(textContent))
@@ -158,9 +155,6 @@ internal static class SemanticKernelMessageMapper
                 foreach (var tc in toolCallsElement.EnumerateArray())
                 {
                     var toolCallId = GetStringProperty(tc, "id");
-                    if (firstToolCallId == null)
-                        firstToolCallId = toolCallId;
-
                     string? functionName = null;
                     object? arguments = null;
 
@@ -189,16 +183,11 @@ internal static class SemanticKernelMessageMapper
                     parts,
                     GetStringProperty(root, "name")));
             }
-
-            return firstToolCallId;
         }
-        catch (JsonException)
-        {
-            return null;
-        }
+        catch (JsonException) { }
     }
 
-    private static void MapToolMessage(string json, List<ChatMessage> messages, string? toolCallId)
+    private static void MapToolMessage(string json, List<ChatMessage> messages)
     {
         try
         {
@@ -208,9 +197,12 @@ internal static class SemanticKernelMessageMapper
             if (string.IsNullOrEmpty(textContent))
                 return;
 
+            // Only set ID if explicitly present in the tool message JSON
+            var id = GetStringProperty(root, "id") ?? GetStringProperty(root, "tool_call_id");
+
             messages.Add(new ChatMessage(
                 MessageRole.Tool,
-                new IMessagePart[] { new ToolCallResponsePart(toolCallId, textContent) }));
+                new IMessagePart[] { new ToolCallResponsePart(id, textContent) }));
         }
         catch (JsonException) { }
     }

--- a/src/Observability/Extensions/SemanticKernel/Utils/SemanticKernelMessageMapper.cs
+++ b/src/Observability/Extensions/SemanticKernel/Utils/SemanticKernelMessageMapper.cs
@@ -1,0 +1,312 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Agents.A365.Observability.Extensions.SemanticKernel.Utils;
+
+using Microsoft.Agents.A365.Observability.Runtime.Tracing;
+using Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.Messages;
+using Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text.Json;
+
+/// <summary>
+/// Maps Semantic Kernel span events to A365 versioned message format.
+/// SK emits gen_ai.* events with <c>gen_ai.event.content</c> JSON payloads;
+/// this mapper converts them to <see cref="InputMessages"/> / <see cref="OutputMessages"/>.
+/// </summary>
+internal static class SemanticKernelMessageMapper
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    /// <summary>
+    /// Maps all input-related span events to a serialized A365 <see cref="InputMessages"/> JSON string.
+    /// Input events: gen_ai.system.message, gen_ai.user.message, gen_ai.assistant.message, gen_ai.tool.message.
+    /// </summary>
+    public static string? MapInputMessages(Activity activity)
+    {
+        if (activity.Events == null)
+            return null;
+
+        var chatMessages = new List<ChatMessage>();
+        string? lastAssistantToolCallId = null;
+
+        foreach (var ev in activity.Events)
+        {
+            var content = GetEventContentTag(ev);
+            if (string.IsNullOrEmpty(content))
+                continue;
+
+            switch (ev.Name)
+            {
+                case "gen_ai.system.message":
+                case "gen_ai.tool.developer":
+                    MapSystemMessage(content, chatMessages);
+                    break;
+
+                case "gen_ai.user.message":
+                    MapUserMessage(content, chatMessages);
+                    break;
+
+                case "gen_ai.assistant.message":
+                    lastAssistantToolCallId = MapAssistantMessage(content, chatMessages);
+                    break;
+
+                case "gen_ai.tool.message":
+                    MapToolMessage(content, chatMessages, lastAssistantToolCallId);
+                    lastAssistantToolCallId = null;
+                    break;
+            }
+        }
+
+        if (chatMessages.Count == 0)
+            return null;
+
+        return MessageUtils.Serialize(new InputMessages(chatMessages));
+    }
+
+    /// <summary>
+    /// Maps gen_ai.choice span events to a serialized A365 <see cref="OutputMessages"/> JSON string.
+    /// </summary>
+    public static string? MapOutputMessages(Activity activity)
+    {
+        if (activity.Events == null)
+            return null;
+
+        var outputMessages = new List<OutputMessage>();
+
+        foreach (var ev in activity.Events)
+        {
+            if (ev.Name != OpenTelemetryConstants.GenAiChoiceEventName)
+                continue;
+
+            var content = GetEventContentTag(ev);
+            if (string.IsNullOrEmpty(content))
+                continue;
+
+            MapChoiceMessage(content, outputMessages);
+        }
+
+        if (outputMessages.Count == 0)
+            return null;
+
+        return MessageUtils.Serialize(new OutputMessages(outputMessages));
+    }
+
+    private static void MapSystemMessage(string json, List<ChatMessage> messages)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            var textContent = GetStringProperty(root, "content");
+            if (string.IsNullOrEmpty(textContent))
+                return;
+
+            messages.Add(new ChatMessage(
+                MessageRole.System,
+                new IMessagePart[] { new TextPart(textContent) },
+                GetStringProperty(root, "name")));
+        }
+        catch (JsonException) { }
+    }
+
+    private static void MapUserMessage(string json, List<ChatMessage> messages)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            var textContent = GetStringProperty(root, "content");
+            if (string.IsNullOrEmpty(textContent))
+                return;
+
+            messages.Add(new ChatMessage(
+                MessageRole.User,
+                new IMessagePart[] { new TextPart(textContent) },
+                GetStringProperty(root, "name")));
+        }
+        catch (JsonException) { }
+    }
+
+    /// <summary>
+    /// Maps an assistant message. Returns the first tool call ID if present (for correlating tool responses).
+    /// </summary>
+    private static string? MapAssistantMessage(string json, List<ChatMessage> messages)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            var parts = new List<IMessagePart>();
+            string? firstToolCallId = null;
+
+            var textContent = GetStringProperty(root, "content");
+            if (!string.IsNullOrEmpty(textContent))
+            {
+                parts.Add(new TextPart(textContent));
+            }
+
+            if (root.TryGetProperty("tool_calls", out var toolCallsElement)
+                && toolCallsElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var tc in toolCallsElement.EnumerateArray())
+                {
+                    var toolCallId = GetStringProperty(tc, "id");
+                    if (firstToolCallId == null)
+                        firstToolCallId = toolCallId;
+
+                    string? functionName = null;
+                    object? arguments = null;
+
+                    if (tc.TryGetProperty("function", out var funcElement))
+                    {
+                        functionName = GetStringProperty(funcElement, "name");
+                        if (funcElement.TryGetProperty("arguments", out var argsElement))
+                        {
+                            arguments = argsElement.ValueKind == JsonValueKind.String
+                                ? argsElement.GetString()
+                                : argsElement.ToString();
+                        }
+                    }
+
+                    if (!string.IsNullOrEmpty(functionName))
+                    {
+                        parts.Add(new ToolCallRequestPart(functionName, toolCallId, arguments));
+                    }
+                }
+            }
+
+            if (parts.Count > 0)
+            {
+                messages.Add(new ChatMessage(
+                    MessageRole.Assistant,
+                    parts,
+                    GetStringProperty(root, "name")));
+            }
+
+            return firstToolCallId;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static void MapToolMessage(string json, List<ChatMessage> messages, string? toolCallId)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            var textContent = GetStringProperty(root, "content");
+            if (string.IsNullOrEmpty(textContent))
+                return;
+
+            messages.Add(new ChatMessage(
+                MessageRole.Tool,
+                new IMessagePart[] { new ToolCallResponsePart(toolCallId, textContent) }));
+        }
+        catch (JsonException) { }
+    }
+
+    private static void MapChoiceMessage(string json, List<OutputMessage> messages)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            if (!root.TryGetProperty("message", out var msgElement))
+                return;
+
+            var parts = new List<IMessagePart>();
+
+            var textContent = GetStringProperty(msgElement, "content");
+            if (!string.IsNullOrEmpty(textContent))
+            {
+                parts.Add(new TextPart(textContent));
+            }
+
+            if (msgElement.TryGetProperty("tool_calls", out var toolCallsElement)
+                && toolCallsElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var tc in toolCallsElement.EnumerateArray())
+                {
+                    var toolCallId = GetStringProperty(tc, "id");
+                    string? functionName = null;
+                    object? arguments = null;
+
+                    if (tc.TryGetProperty("function", out var funcElement))
+                    {
+                        functionName = GetStringProperty(funcElement, "name");
+                        if (funcElement.TryGetProperty("arguments", out var argsElement))
+                        {
+                            arguments = argsElement.ValueKind == JsonValueKind.String
+                                ? argsElement.GetString()
+                                : argsElement.ToString();
+                        }
+                    }
+
+                    if (!string.IsNullOrEmpty(functionName))
+                    {
+                        parts.Add(new ToolCallRequestPart(functionName, toolCallId, arguments));
+                    }
+                }
+            }
+
+            if (parts.Count == 0)
+                return;
+
+            var role = MapRole(GetStringProperty(msgElement, "role"));
+            var finishReason = MapFinishReason(GetStringProperty(root, "finish_reason"));
+
+            messages.Add(new OutputMessage(role, parts, finishReason: finishReason));
+        }
+        catch (JsonException) { }
+    }
+
+    private static MessageRole MapRole(string? role)
+    {
+        if (string.IsNullOrEmpty(role))
+            return MessageRole.Assistant;
+
+        if (role.Equals("system", System.StringComparison.OrdinalIgnoreCase)) return MessageRole.System;
+        if (role.Equals("user", System.StringComparison.OrdinalIgnoreCase)) return MessageRole.User;
+        if (role.Equals("assistant", System.StringComparison.OrdinalIgnoreCase)) return MessageRole.Assistant;
+        if (role.Equals("tool", System.StringComparison.OrdinalIgnoreCase)) return MessageRole.Tool;
+
+        return MessageRole.Assistant;
+    }
+
+    private static string? MapFinishReason(string? skFinishReason)
+    {
+        if (string.IsNullOrEmpty(skFinishReason))
+            return null;
+
+        if (skFinishReason.Equals("Stop", System.StringComparison.OrdinalIgnoreCase)) return "stop";
+        if (skFinishReason.Equals("Length", System.StringComparison.OrdinalIgnoreCase)) return "length";
+        if (skFinishReason.Equals("ContentFilter", System.StringComparison.OrdinalIgnoreCase)) return "content_filter";
+        if (skFinishReason.Equals("ToolCalls", System.StringComparison.OrdinalIgnoreCase)) return "tool_calls";
+
+        return skFinishReason.ToLowerInvariant();
+    }
+
+    private static string? GetEventContentTag(ActivityEvent activityEvent)
+    {
+        return activityEvent.Tags?
+            .FirstOrDefault(tag => tag.Key == SemanticKernelTelemetryConstants.EventContentTag).Value as string;
+    }
+
+    private static string? GetStringProperty(JsonElement element, string propertyName)
+    {
+        if (element.TryGetProperty(propertyName, out var prop) && prop.ValueKind == JsonValueKind.String)
+            return prop.GetString();
+        return null;
+    }
+}

--- a/src/Observability/Extensions/SemanticKernel/Utils/SemanticKernelMessageMapper.cs
+++ b/src/Observability/Extensions/SemanticKernel/Utils/SemanticKernelMessageMapper.cs
@@ -18,12 +18,6 @@ using System.Text.Json;
 /// </summary>
 internal static class SemanticKernelMessageMapper
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        WriteIndented = false
-    };
-
     /// <summary>
     /// Maps all input-related span events to a serialized A365 <see cref="InputMessages"/> JSON string.
     /// Input events: gen_ai.system.message, gen_ai.user.message, gen_ai.assistant.message, gen_ai.tool.message.

--- a/src/Observability/Runtime/Microsoft.Agents.A365.Observability.Runtime.csproj
+++ b/src/Observability/Runtime/Microsoft.Agents.A365.Observability.Runtime.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.Agents.A365.Observability.Hosting" />
     <InternalsVisibleTo Include="Microsoft.Agents.A365.Observability.Extensions.SemanticKernel" />
+    <InternalsVisibleTo Include="Microsoft.Agents.A365.Observability.Extensions.AgentFramework" />
     <InternalsVisibleTo Include="Microsoft.Agents.A365.Observability.Runtime.Tests" />
   </ItemGroup>
 </Project>

--- a/src/Tests/Microsoft.Agents.A365.Observability.Extensions.IntegrationTests/AgentFrameworkSpanProcessorTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Extensions.IntegrationTests/AgentFrameworkSpanProcessorTests.cs
@@ -1,41 +1,50 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.ClientModel;
 using System.Diagnostics;
 using System.Text.Json;
+using Azure.AI.OpenAI;
 using FluentAssertions;
 using Microsoft.Agents.A365.Observability.Extensions.AgentFramework;
 using Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes;
+using Microsoft.Extensions.AI;
 using OpenTelemetry;
 using OpenTelemetry.Trace;
 
 namespace Microsoft.Agents.A365.Observability.Extensions.IntegrationTests;
 
 /// <summary>
-/// Integration tests for <see cref="AgentFrameworkSpanProcessor"/> verifying the mapping from
-/// Agent Framework message format to A365 versioned message format.
-/// Agent Framework sets gen_ai.input.messages / gen_ai.output.messages as span tags with
-/// JSON arrays of {role, parts[{type, content}], finish_reason?}. The processor should
-/// convert these to the A365 versioned format {version, messages[{role, parts[...]}]}.
+/// Integration tests for <see cref="AgentFrameworkSpanProcessor"/> running against real Azure OpenAI
+/// via <see cref="IChatClient"/> with <c>UseOpenTelemetry()</c> — the same pipeline used by Agent Framework.
+/// Pipeline: IChatClient.UseOpenTelemetry() → TracerProvider → AgentFrameworkSpanProcessor → captured spans.
+/// Requires: AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_API_KEY, AZURE_OPENAI_DEPLOYMENT env vars.
 /// </summary>
 [TestClass]
 public class AgentFrameworkSpanProcessorTests
 {
     private static readonly JsonSerializerOptions JsonPrint = new() { WriteIndented = true };
-    private static readonly string SourceName = BuilderExtensions.AgentFrameworkSource;
+    private const string OTelSourceName = BuilderExtensions.AgentFrameworkChatClientSource;
+
+    private static string? Endpoint => Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT");
+    private static string? ApiKey => Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY");
+    private static string? Deployment => Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT");
+
+    private static bool HasCredentials =>
+        !string.IsNullOrEmpty(Endpoint) &&
+        !string.IsNullOrEmpty(ApiKey) &&
+        !string.IsNullOrEmpty(Deployment);
 
     private List<Activity> _exportedActivities = new();
     private TracerProvider? _tracerProvider;
-    private ActivitySource? _activitySource;
 
     [TestInitialize]
     public void Setup()
     {
         _exportedActivities = new List<Activity>();
-        _activitySource = new ActivitySource(SourceName);
 
         _tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(SourceName)
+            .AddSource(OTelSourceName)
             .AddProcessor(new AgentFrameworkSpanProcessor())
             .AddProcessor(new ActivityCapturingProcessor(_exportedActivities))
             .Build();
@@ -44,220 +53,176 @@ public class AgentFrameworkSpanProcessorTests
     [TestCleanup]
     public void Cleanup()
     {
-        _activitySource?.Dispose();
         _tracerProvider?.Dispose();
     }
 
     [TestMethod]
-    public void SimpleChat_MapsToVersionedInputAndOutputMessages()
+    public async Task SimpleChat_ProcessorMapsToVersionedFormat()
     {
-        // Arrange — simulate what Agent Framework emits for a simple chat
-        var inputJson = @"[
-            {""role"": ""system"", ""parts"": [{""type"": ""text"", ""content"": ""You are a helpful assistant.""}]},
-            {""role"": ""user"", ""parts"": [{""type"": ""text"", ""content"": ""What is the capital of France?""}]}
-        ]";
-        var outputJson = @"[
-            {""role"": ""assistant"", ""parts"": [{""type"": ""text"", ""content"": ""The capital of France is Paris.""}], ""finish_reason"": ""stop""}
-        ]";
+        SkipIfNoCredentials();
 
-        using (var activity = _activitySource!.StartActivity("chat gpt-4o-mini", ActivityKind.Client))
+        var chatClient = CreateChatClient();
+        var messages = new List<ChatMessage>
         {
-            activity!.SetTag("gen_ai.operation.name", "chat");
-            activity.SetTag("gen_ai.input.messages", inputJson);
-            activity.SetTag("gen_ai.output.messages", outputJson);
-        }
+            new(ChatRole.System, "You are a helpful assistant. Reply in one sentence."),
+            new(ChatRole.User, "What is the capital of France?")
+        };
+
+        await chatClient.GetResponseAsync(messages);
 
         _tracerProvider!.ForceFlush();
 
-        // Assert
-        _exportedActivities.Should().HaveCount(1);
-        var span = _exportedActivities[0];
-        DumpActivity(span, "AF SimpleChat");
+        var chatSpan = FindChatSpan();
+        chatSpan.Should().NotBeNull("IChatClient should emit a chat span");
+        DumpActivity(chatSpan!, "AF SimpleChat");
 
-        var input = span.GetTagItem("gen_ai.input.messages") as string;
+        var tags = GetTags(chatSpan!);
+
+        // Verify the processor mapped to A365 versioned format
+        tags.Should().ContainKey("gen_ai.input.messages");
+        var input = tags["gen_ai.input.messages"] as string;
         input.Should().Contain("\"version\":\"0.1.0\"", "should produce versioned wrapper");
-        input.Should().Contain("\"role\":\"system\"", "should preserve system message");
-        input.Should().Contain("\"role\":\"user\"", "should preserve user message");
         input.Should().Contain("\"type\":\"text\"", "should use TextPart format");
         input.Should().Contain("capital of France");
 
-        var output = span.GetTagItem("gen_ai.output.messages") as string;
+        tags.Should().ContainKey("gen_ai.output.messages");
+        var output = tags["gen_ai.output.messages"] as string;
         output.Should().Contain("\"version\":\"0.1.0\"");
-        output.Should().Contain("\"role\":\"assistant\"");
         output.Should().Contain("\"type\":\"text\"");
-        output.Should().Contain("Paris");
-        output.Should().Contain("\"finish_reason\":\"stop\"");
+        output.Should().Contain("\"role\":\"assistant\"");
     }
 
     [TestMethod]
-    public void ToolCallConversation_MapsToolCallAndResponseParts()
+    public async Task ChatWithToolCall_ProcessorMapsToolCallParts()
     {
-        // Arrange — simulate a tool call round-trip
-        var inputJson = @"[
-            {""role"": ""system"", ""parts"": [{""type"": ""text"", ""content"": ""You are a weather assistant.""}]},
-            {""role"": ""user"", ""parts"": [{""type"": ""text"", ""content"": ""What is the weather in Seattle?""}]},
-            {""role"": ""assistant"", ""parts"": [{""type"": ""tool_call"", ""name"": ""GetWeather"", ""id"": ""call_123"", ""arguments"": ""{\""location\"": \""Seattle\""}""}]},
-            {""role"": ""tool"", ""parts"": [{""type"": ""tool_call_response"", ""id"": ""call_123"", ""response"": ""Sunny, 72°F""}]}
-        ]";
-        var outputJson = @"[
-            {""role"": ""assistant"", ""parts"": [{""type"": ""text"", ""content"": ""The weather in Seattle is sunny with 72°F.""}], ""finish_reason"": ""stop""}
-        ]";
+        SkipIfNoCredentials();
 
-        using (var activity = _activitySource!.StartActivity("chat gpt-4o-mini", ActivityKind.Client))
+        var chatClient = CreateChatClientWithTools();
+        var messages = new List<ChatMessage>
         {
-            activity!.SetTag("gen_ai.operation.name", "chat");
-            activity.SetTag("gen_ai.input.messages", inputJson);
-            activity.SetTag("gen_ai.output.messages", outputJson);
-        }
+            new(ChatRole.System, "You are a weather assistant. Always use the GetWeather function."),
+            new(ChatRole.User, "What's the weather in Seattle?")
+        };
+
+        await chatClient.GetResponseAsync(messages);
 
         _tracerProvider!.ForceFlush();
 
-        _exportedActivities.Should().HaveCount(1);
-        var span = _exportedActivities[0];
-        DumpActivity(span, "AF ToolCall");
+        // Dump all spans to see what the full pipeline emits
+        Console.WriteLine($"\n  All captured activities ({_exportedActivities.Count}):");
+        foreach (var act in _exportedActivities)
+        {
+            var op = act.GetTagItem("gen_ai.operation.name") as string ?? "(none)";
+            Console.WriteLine($"    {act.Source.Name} | {act.DisplayName} | op={op}");
+            DumpActivity(act, $"AF ToolCall — {act.DisplayName}");
+        }
 
-        var input = span.GetTagItem("gen_ai.input.messages") as string;
+        // Find a chat span that has input messages
+        var chatSpan = _exportedActivities.LastOrDefault(a =>
+        {
+            var input = a.GetTagItem("gen_ai.input.messages") as string;
+            return input != null && input.Contains("version");
+        });
+
+        chatSpan.Should().NotBeNull("should have at least one span with versioned input messages");
+
+        var tags = GetTags(chatSpan!);
+        var input = tags["gen_ai.input.messages"] as string;
         input.Should().Contain("\"version\":\"0.1.0\"");
-        input.Should().Contain("\"type\":\"tool_call\"", "should map tool_call parts");
-        input.Should().Contain("\"name\":\"GetWeather\"");
-        input.Should().Contain("\"id\":\"call_123\"");
-        input.Should().Contain("\"type\":\"tool_call_response\"", "should map tool_call_response parts");
-        input.Should().Contain("Sunny, 72");
+        input.Should().Contain("weather");
     }
 
     [TestMethod]
-    public void MultimodalMessage_MapsBlobAndUriParts()
+    public async Task SimpleChat_RawFormatBeforeProcessor()
     {
-        // Arrange — simulate a multimodal message with blob and uri parts
-        var inputJson = @"[
-            {""role"": ""user"", ""parts"": [
-                {""type"": ""text"", ""content"": ""Describe this image""},
-                {""type"": ""blob"", ""modality"": ""image"", ""content"": ""aW1hZ2VkYXRh"", ""mime_type"": ""image/png""},
-                {""type"": ""uri"", ""modality"": ""image"", ""uri"": ""https://example.com/image.png"", ""mime_type"": ""image/png""}
-            ]}
-        ]";
+        SkipIfNoCredentials();
 
-        using (var activity = _activitySource!.StartActivity("chat gpt-4o-mini", ActivityKind.Client))
+        // Capture spans WITHOUT the processor to see raw IChatClient format
+        _tracerProvider?.Dispose();
+        var rawActivities = new List<Activity>();
+        _tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(OTelSourceName)
+            .AddProcessor(new ActivityCapturingProcessor(rawActivities))
+            .Build();
+
+        var chatClient = CreateChatClient();
+        var messages = new List<ChatMessage>
         {
-            activity!.SetTag("gen_ai.operation.name", "chat");
-            activity.SetTag("gen_ai.input.messages", inputJson);
-        }
+            new(ChatRole.User, "Say hello")
+        };
+
+        await chatClient.GetResponseAsync(messages);
 
         _tracerProvider!.ForceFlush();
 
-        _exportedActivities.Should().HaveCount(1);
-        var span = _exportedActivities[0];
-        DumpActivity(span, "AF Multimodal");
+        var chatSpan = rawActivities.FirstOrDefault(a =>
+            a.GetTagItem("gen_ai.operation.name") as string == "chat");
 
-        var input = span.GetTagItem("gen_ai.input.messages") as string;
-        input.Should().Contain("\"version\":\"0.1.0\"");
-        input.Should().Contain("\"type\":\"text\"");
-        input.Should().Contain("Describe this image");
-        input.Should().Contain("\"type\":\"blob\"", "should map blob parts");
-        input.Should().Contain("\"modality\":\"image\"");
-        input.Should().Contain("\"type\":\"uri\"", "should map uri parts");
-        input.Should().Contain("https://example.com/image.png");
-    }
+        chatSpan.Should().NotBeNull("IChatClient should emit a chat span");
+        DumpActivity(chatSpan!, "AF Raw (no processor)");
 
-    [TestMethod]
-    public void InvokeAgentOperation_MapsMessages()
-    {
-        // Arrange — invoke_agent operation also gets mapped
-        var inputJson = @"[
-            {""role"": ""user"", ""parts"": [{""type"": ""text"", ""content"": ""Hello agent""}]}
-        ]";
-        var outputJson = @"[
-            {""role"": ""assistant"", ""parts"": [{""type"": ""text"", ""content"": ""Hello! How can I help?""}], ""finish_reason"": ""stop""}
-        ]";
+        // Document the raw format that Microsoft.Extensions.AI emits
+        var tags = GetTags(chatSpan!);
+        tags.Should().ContainKey("gen_ai.input.messages",
+            "Microsoft.Extensions.AI UseOpenTelemetry should emit input messages");
+        tags.Should().ContainKey("gen_ai.output.messages",
+            "Microsoft.Extensions.AI UseOpenTelemetry should emit output messages");
 
-        using (var activity = _activitySource!.StartActivity("invoke_agent TestAgent", ActivityKind.Internal))
-        {
-            activity!.SetTag("gen_ai.operation.name", "invoke_agent");
-            activity.SetTag("gen_ai.input.messages", inputJson);
-            activity.SetTag("gen_ai.output.messages", outputJson);
-        }
-
-        _tracerProvider!.ForceFlush();
-
-        _exportedActivities.Should().HaveCount(1);
-        var span = _exportedActivities[0];
-        DumpActivity(span, "AF InvokeAgent");
-
-        var input = span.GetTagItem("gen_ai.input.messages") as string;
-        input.Should().Contain("\"version\":\"0.1.0\"");
-        input.Should().Contain("Hello agent");
-
-        var output = span.GetTagItem("gen_ai.output.messages") as string;
-        output.Should().Contain("\"version\":\"0.1.0\"");
-        output.Should().Contain("Hello! How can I help?");
-    }
-
-    [TestMethod]
-    public void ExecuteToolOperation_CopiesResultToEventContent()
-    {
-        // Arrange — execute_tool copies tool result to gen_ai.event.content
-        using (var activity = _activitySource!.StartActivity("execute_tool GetWeather", ActivityKind.Internal))
-        {
-            activity!.SetTag("gen_ai.operation.name", "execute_tool");
-            activity.SetTag("gen_ai.tool.call.result", "Sunny, 72°F");
-        }
-
-        _tracerProvider!.ForceFlush();
-
-        _exportedActivities.Should().HaveCount(1);
-        var span = _exportedActivities[0];
-
-        var eventContent = span.GetTagItem("gen_ai.event.content") as string;
-        eventContent.Should().Be("Sunny, 72°F");
-    }
-
-    [TestMethod]
-    public void ReasoningPart_MapsCorrectly()
-    {
-        var inputJson = @"[
-            {""role"": ""assistant"", ""parts"": [
-                {""type"": ""reasoning"", ""content"": ""Let me think about this step by step...""},
-                {""type"": ""text"", ""content"": ""The answer is 42.""}
-            ]}
-        ]";
-
-        using (var activity = _activitySource!.StartActivity("chat gpt-4o-mini", ActivityKind.Client))
-        {
-            activity!.SetTag("gen_ai.operation.name", "chat");
-            activity.SetTag("gen_ai.input.messages", inputJson);
-        }
-
-        _tracerProvider!.ForceFlush();
-
-        var span = _exportedActivities[0];
-        DumpActivity(span, "AF Reasoning");
-
-        var input = span.GetTagItem("gen_ai.input.messages") as string;
-        input.Should().Contain("\"version\":\"0.1.0\"");
-        input.Should().Contain("\"type\":\"reasoning\"", "should map reasoning parts");
-        input.Should().Contain("step by step");
-        input.Should().Contain("\"type\":\"text\"");
-        input.Should().Contain("answer is 42");
-    }
-
-    [TestMethod]
-    public void InvalidJson_PreservesOriginal()
-    {
-        using (var activity = _activitySource!.StartActivity("chat gpt-4o-mini", ActivityKind.Client))
-        {
-            activity!.SetTag("gen_ai.operation.name", "chat");
-            activity.SetTag("gen_ai.input.messages", "not valid json");
-        }
-
-        _tracerProvider!.ForceFlush();
-
-        var span = _exportedActivities[0];
-        // Mapper returns null for invalid JSON, so the original tag stays
-        var input = span.GetTagItem("gen_ai.input.messages") as string;
-        input.Should().Be("not valid json", "invalid JSON should be left unchanged");
+        // Log the raw format for analysis
+        Console.WriteLine($"\n  Raw gen_ai.input.messages:\n{tags["gen_ai.input.messages"]}");
+        Console.WriteLine($"\n  Raw gen_ai.output.messages:\n{tags["gen_ai.output.messages"]}");
     }
 
     #region Helpers
+
+    private IChatClient CreateChatClient()
+    {
+        return new AzureOpenAIClient(
+                new Uri(Endpoint!),
+                new ApiKeyCredential(ApiKey!))
+            .GetChatClient(Deployment!)
+            .AsIChatClient()
+            .AsBuilder()
+            .UseOpenTelemetry(
+                sourceName: OTelSourceName,
+                configure: cfg => cfg.EnableSensitiveData = true)
+            .Build();
+    }
+
+    private IChatClient CreateChatClientWithTools()
+    {
+        return new AzureOpenAIClient(
+                new Uri(Endpoint!),
+                new ApiKeyCredential(ApiKey!))
+            .GetChatClient(Deployment!)
+            .AsIChatClient()
+            .AsBuilder()
+            .UseFunctionInvocation()
+            .UseOpenTelemetry(
+                sourceName: OTelSourceName,
+                configure: cfg => cfg.EnableSensitiveData = true)
+            .Build();
+    }
+
+    private Activity? FindChatSpan()
+    {
+        return _exportedActivities.FirstOrDefault(a =>
+            a.GetTagItem("gen_ai.operation.name") as string == "chat");
+    }
+
+    private static void SkipIfNoCredentials()
+    {
+        if (!HasCredentials)
+        {
+            Assert.Inconclusive(
+                "Skipped: set AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_API_KEY, AZURE_OPENAI_DEPLOYMENT env vars to run.");
+        }
+    }
+
+    private static Dictionary<string, object?> GetTags(Activity activity)
+    {
+        return activity.TagObjects.ToDictionary(t => t.Key, t => t.Value);
+    }
 
     private static void DumpActivity(Activity activity, string label)
     {

--- a/src/Tests/Microsoft.Agents.A365.Observability.Extensions.IntegrationTests/AgentFrameworkSpanProcessorTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Extensions.IntegrationTests/AgentFrameworkSpanProcessorTests.cs
@@ -1,0 +1,308 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Agents.A365.Observability.Extensions.AgentFramework;
+using Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+
+namespace Microsoft.Agents.A365.Observability.Extensions.IntegrationTests;
+
+/// <summary>
+/// Integration tests for <see cref="AgentFrameworkSpanProcessor"/> verifying the mapping from
+/// Agent Framework message format to A365 versioned message format.
+/// Agent Framework sets gen_ai.input.messages / gen_ai.output.messages as span tags with
+/// JSON arrays of {role, parts[{type, content}], finish_reason?}. The processor should
+/// convert these to the A365 versioned format {version, messages[{role, parts[...]}]}.
+/// </summary>
+[TestClass]
+public class AgentFrameworkSpanProcessorTests
+{
+    private static readonly JsonSerializerOptions JsonPrint = new() { WriteIndented = true };
+    private static readonly string SourceName = BuilderExtensions.AgentFrameworkSource;
+
+    private List<Activity> _exportedActivities = new();
+    private TracerProvider? _tracerProvider;
+    private ActivitySource? _activitySource;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _exportedActivities = new List<Activity>();
+        _activitySource = new ActivitySource(SourceName);
+
+        _tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(SourceName)
+            .AddProcessor(new AgentFrameworkSpanProcessor())
+            .AddProcessor(new ActivityCapturingProcessor(_exportedActivities))
+            .Build();
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        _activitySource?.Dispose();
+        _tracerProvider?.Dispose();
+    }
+
+    [TestMethod]
+    public void SimpleChat_MapsToVersionedInputAndOutputMessages()
+    {
+        // Arrange — simulate what Agent Framework emits for a simple chat
+        var inputJson = @"[
+            {""role"": ""system"", ""parts"": [{""type"": ""text"", ""content"": ""You are a helpful assistant.""}]},
+            {""role"": ""user"", ""parts"": [{""type"": ""text"", ""content"": ""What is the capital of France?""}]}
+        ]";
+        var outputJson = @"[
+            {""role"": ""assistant"", ""parts"": [{""type"": ""text"", ""content"": ""The capital of France is Paris.""}], ""finish_reason"": ""stop""}
+        ]";
+
+        using (var activity = _activitySource!.StartActivity("chat gpt-4o-mini", ActivityKind.Client))
+        {
+            activity!.SetTag("gen_ai.operation.name", "chat");
+            activity.SetTag("gen_ai.input.messages", inputJson);
+            activity.SetTag("gen_ai.output.messages", outputJson);
+        }
+
+        _tracerProvider!.ForceFlush();
+
+        // Assert
+        _exportedActivities.Should().HaveCount(1);
+        var span = _exportedActivities[0];
+        DumpActivity(span, "AF SimpleChat");
+
+        var input = span.GetTagItem("gen_ai.input.messages") as string;
+        input.Should().Contain("\"version\":\"0.1.0\"", "should produce versioned wrapper");
+        input.Should().Contain("\"role\":\"system\"", "should preserve system message");
+        input.Should().Contain("\"role\":\"user\"", "should preserve user message");
+        input.Should().Contain("\"type\":\"text\"", "should use TextPart format");
+        input.Should().Contain("capital of France");
+
+        var output = span.GetTagItem("gen_ai.output.messages") as string;
+        output.Should().Contain("\"version\":\"0.1.0\"");
+        output.Should().Contain("\"role\":\"assistant\"");
+        output.Should().Contain("\"type\":\"text\"");
+        output.Should().Contain("Paris");
+        output.Should().Contain("\"finish_reason\":\"stop\"");
+    }
+
+    [TestMethod]
+    public void ToolCallConversation_MapsToolCallAndResponseParts()
+    {
+        // Arrange — simulate a tool call round-trip
+        var inputJson = @"[
+            {""role"": ""system"", ""parts"": [{""type"": ""text"", ""content"": ""You are a weather assistant.""}]},
+            {""role"": ""user"", ""parts"": [{""type"": ""text"", ""content"": ""What is the weather in Seattle?""}]},
+            {""role"": ""assistant"", ""parts"": [{""type"": ""tool_call"", ""name"": ""GetWeather"", ""id"": ""call_123"", ""arguments"": ""{\""location\"": \""Seattle\""}""}]},
+            {""role"": ""tool"", ""parts"": [{""type"": ""tool_call_response"", ""id"": ""call_123"", ""response"": ""Sunny, 72°F""}]}
+        ]";
+        var outputJson = @"[
+            {""role"": ""assistant"", ""parts"": [{""type"": ""text"", ""content"": ""The weather in Seattle is sunny with 72°F.""}], ""finish_reason"": ""stop""}
+        ]";
+
+        using (var activity = _activitySource!.StartActivity("chat gpt-4o-mini", ActivityKind.Client))
+        {
+            activity!.SetTag("gen_ai.operation.name", "chat");
+            activity.SetTag("gen_ai.input.messages", inputJson);
+            activity.SetTag("gen_ai.output.messages", outputJson);
+        }
+
+        _tracerProvider!.ForceFlush();
+
+        _exportedActivities.Should().HaveCount(1);
+        var span = _exportedActivities[0];
+        DumpActivity(span, "AF ToolCall");
+
+        var input = span.GetTagItem("gen_ai.input.messages") as string;
+        input.Should().Contain("\"version\":\"0.1.0\"");
+        input.Should().Contain("\"type\":\"tool_call\"", "should map tool_call parts");
+        input.Should().Contain("\"name\":\"GetWeather\"");
+        input.Should().Contain("\"id\":\"call_123\"");
+        input.Should().Contain("\"type\":\"tool_call_response\"", "should map tool_call_response parts");
+        input.Should().Contain("Sunny, 72");
+    }
+
+    [TestMethod]
+    public void MultimodalMessage_MapsBlobAndUriParts()
+    {
+        // Arrange — simulate a multimodal message with blob and uri parts
+        var inputJson = @"[
+            {""role"": ""user"", ""parts"": [
+                {""type"": ""text"", ""content"": ""Describe this image""},
+                {""type"": ""blob"", ""modality"": ""image"", ""content"": ""aW1hZ2VkYXRh"", ""mime_type"": ""image/png""},
+                {""type"": ""uri"", ""modality"": ""image"", ""uri"": ""https://example.com/image.png"", ""mime_type"": ""image/png""}
+            ]}
+        ]";
+
+        using (var activity = _activitySource!.StartActivity("chat gpt-4o-mini", ActivityKind.Client))
+        {
+            activity!.SetTag("gen_ai.operation.name", "chat");
+            activity.SetTag("gen_ai.input.messages", inputJson);
+        }
+
+        _tracerProvider!.ForceFlush();
+
+        _exportedActivities.Should().HaveCount(1);
+        var span = _exportedActivities[0];
+        DumpActivity(span, "AF Multimodal");
+
+        var input = span.GetTagItem("gen_ai.input.messages") as string;
+        input.Should().Contain("\"version\":\"0.1.0\"");
+        input.Should().Contain("\"type\":\"text\"");
+        input.Should().Contain("Describe this image");
+        input.Should().Contain("\"type\":\"blob\"", "should map blob parts");
+        input.Should().Contain("\"modality\":\"image\"");
+        input.Should().Contain("\"type\":\"uri\"", "should map uri parts");
+        input.Should().Contain("https://example.com/image.png");
+    }
+
+    [TestMethod]
+    public void InvokeAgentOperation_MapsMessages()
+    {
+        // Arrange — invoke_agent operation also gets mapped
+        var inputJson = @"[
+            {""role"": ""user"", ""parts"": [{""type"": ""text"", ""content"": ""Hello agent""}]}
+        ]";
+        var outputJson = @"[
+            {""role"": ""assistant"", ""parts"": [{""type"": ""text"", ""content"": ""Hello! How can I help?""}], ""finish_reason"": ""stop""}
+        ]";
+
+        using (var activity = _activitySource!.StartActivity("invoke_agent TestAgent", ActivityKind.Internal))
+        {
+            activity!.SetTag("gen_ai.operation.name", "invoke_agent");
+            activity.SetTag("gen_ai.input.messages", inputJson);
+            activity.SetTag("gen_ai.output.messages", outputJson);
+        }
+
+        _tracerProvider!.ForceFlush();
+
+        _exportedActivities.Should().HaveCount(1);
+        var span = _exportedActivities[0];
+        DumpActivity(span, "AF InvokeAgent");
+
+        var input = span.GetTagItem("gen_ai.input.messages") as string;
+        input.Should().Contain("\"version\":\"0.1.0\"");
+        input.Should().Contain("Hello agent");
+
+        var output = span.GetTagItem("gen_ai.output.messages") as string;
+        output.Should().Contain("\"version\":\"0.1.0\"");
+        output.Should().Contain("Hello! How can I help?");
+    }
+
+    [TestMethod]
+    public void ExecuteToolOperation_CopiesResultToEventContent()
+    {
+        // Arrange — execute_tool copies tool result to gen_ai.event.content
+        using (var activity = _activitySource!.StartActivity("execute_tool GetWeather", ActivityKind.Internal))
+        {
+            activity!.SetTag("gen_ai.operation.name", "execute_tool");
+            activity.SetTag("gen_ai.tool.call.result", "Sunny, 72°F");
+        }
+
+        _tracerProvider!.ForceFlush();
+
+        _exportedActivities.Should().HaveCount(1);
+        var span = _exportedActivities[0];
+
+        var eventContent = span.GetTagItem("gen_ai.event.content") as string;
+        eventContent.Should().Be("Sunny, 72°F");
+    }
+
+    [TestMethod]
+    public void ReasoningPart_MapsCorrectly()
+    {
+        var inputJson = @"[
+            {""role"": ""assistant"", ""parts"": [
+                {""type"": ""reasoning"", ""content"": ""Let me think about this step by step...""},
+                {""type"": ""text"", ""content"": ""The answer is 42.""}
+            ]}
+        ]";
+
+        using (var activity = _activitySource!.StartActivity("chat gpt-4o-mini", ActivityKind.Client))
+        {
+            activity!.SetTag("gen_ai.operation.name", "chat");
+            activity.SetTag("gen_ai.input.messages", inputJson);
+        }
+
+        _tracerProvider!.ForceFlush();
+
+        var span = _exportedActivities[0];
+        DumpActivity(span, "AF Reasoning");
+
+        var input = span.GetTagItem("gen_ai.input.messages") as string;
+        input.Should().Contain("\"version\":\"0.1.0\"");
+        input.Should().Contain("\"type\":\"reasoning\"", "should map reasoning parts");
+        input.Should().Contain("step by step");
+        input.Should().Contain("\"type\":\"text\"");
+        input.Should().Contain("answer is 42");
+    }
+
+    [TestMethod]
+    public void InvalidJson_PreservesOriginal()
+    {
+        using (var activity = _activitySource!.StartActivity("chat gpt-4o-mini", ActivityKind.Client))
+        {
+            activity!.SetTag("gen_ai.operation.name", "chat");
+            activity.SetTag("gen_ai.input.messages", "not valid json");
+        }
+
+        _tracerProvider!.ForceFlush();
+
+        var span = _exportedActivities[0];
+        // Mapper returns null for invalid JSON, so the original tag stays
+        var input = span.GetTagItem("gen_ai.input.messages") as string;
+        input.Should().Be("not valid json", "invalid JSON should be left unchanged");
+    }
+
+    #region Helpers
+
+    private static void DumpActivity(Activity activity, string label)
+    {
+        Console.WriteLine($"\n=== {label} ===");
+        Console.WriteLine($"  Source: {activity.Source.Name}  Kind: {activity.Kind}  Duration: {activity.Duration}");
+
+        Console.WriteLine("  Attributes:");
+        foreach (var tag in activity.TagObjects)
+            Console.WriteLine($"    {tag.Key} = {FormatValue(tag.Value)}");
+
+        if (activity.Events.Any())
+        {
+            Console.WriteLine($"  Events ({activity.Events.Count()}):");
+            foreach (var ev in activity.Events)
+            {
+                Console.WriteLine($"    '{ev.Name}'");
+                foreach (var attr in ev.Tags)
+                    Console.WriteLine($"      {attr.Key} = {FormatValue(attr.Value)}");
+            }
+        }
+        Console.WriteLine("===\n");
+    }
+
+    private static string FormatValue(object? value)
+    {
+        string val = value switch
+        {
+            string s => s,
+            string[] arr => $"[{string.Join(", ", arr)}]",
+            null => "(null)",
+            _ => value.ToString() ?? "(null)"
+        };
+
+        if (val.Length > 120)
+        {
+            try
+            {
+                var doc = JsonDocument.Parse(val);
+                val = "\n      " + JsonSerializer.Serialize(doc.RootElement, JsonPrint).Replace("\n", "\n      ");
+            }
+            catch { }
+        }
+
+        return val;
+    }
+
+    #endregion
+}

--- a/src/Tests/Microsoft.Agents.A365.Observability.Extensions.IntegrationTests/Microsoft.Agents.A365.Observability.Extensions.IntegrationTests.csproj
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Extensions.IntegrationTests/Microsoft.Agents.A365.Observability.Extensions.IntegrationTests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\..\Observability\Extensions\OpenAI\Microsoft.Agents.A365.Observability.Extensions.OpenAI.csproj" />
+    <ProjectReference Include="..\..\Observability\Extensions\SemanticKernel\Microsoft.Agents.A365.Observability.Extensions.SemanticKernel.csproj" />
+    <ProjectReference Include="..\..\Observability\Extensions\AgentFramework\Microsoft.Agents.A365.Observability.Extensions.AgentFramework.csproj" />
+    <ProjectReference Include="..\..\Observability\Runtime\Microsoft.Agents.A365.Observability.Runtime.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Tests/Microsoft.Agents.A365.Observability.Extensions.IntegrationTests/Microsoft.Agents.A365.Observability.Extensions.IntegrationTests.csproj
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Extensions.IntegrationTests/Microsoft.Agents.A365.Observability.Extensions.IntegrationTests.csproj
@@ -14,6 +14,9 @@
     <PackageReference Include="MSTest.TestFramework" />
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.AI" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
+    <PackageReference Include="Azure.AI.OpenAI" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Tests/Microsoft.Agents.A365.Observability.Extensions.IntegrationTests/OpenAISpanProcessorTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Extensions.IntegrationTests/OpenAISpanProcessorTests.cs
@@ -1,0 +1,304 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.ClientModel;
+using System.Diagnostics;
+using System.Text.Json;
+using Azure.AI.OpenAI;
+using FluentAssertions;
+using Microsoft.Agents.A365.Observability.Extensions.OpenAI;
+using OpenAI.Chat;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+
+namespace Microsoft.Agents.A365.Observability.Extensions.IntegrationTests;
+
+/// <summary>
+/// Integration tests for <see cref="OpenAISpanProcessor"/> running against real Azure OpenAI spans.
+/// The tests wire up the full OTel pipeline: OpenAI SDK → TracerProvider → OpenAISpanProcessor → captured spans.
+/// This lets us assert on the span attributes after the processor runs and test any mapping logic.
+/// Requires: AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_API_KEY, AZURE_OPENAI_DEPLOYMENT env vars.
+/// </summary>
+[TestClass]
+public class OpenAISpanProcessorTests
+{
+    private static readonly JsonSerializerOptions JsonPrint = new() { WriteIndented = true };
+
+    private static string? Endpoint => Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT");
+    private static string? ApiKey => Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY");
+    private static string? Deployment => Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT");
+
+    private static bool HasCredentials =>
+        !string.IsNullOrEmpty(Endpoint) &&
+        !string.IsNullOrEmpty(ApiKey) &&
+        !string.IsNullOrEmpty(Deployment);
+
+    private List<Activity> _exportedActivities = new();
+    private TracerProvider? _tracerProvider;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        AppContext.SetSwitch("OpenAI.Experimental.EnableOpenTelemetry", true);
+
+        _exportedActivities = new List<Activity>();
+
+        // Wire up the full pipeline: OpenAI source → OpenAISpanProcessor → capture exporter
+        _tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource("OpenAI.*")
+            .AddProcessor(new OpenAISpanProcessor())
+            .AddProcessor(new ActivityCapturingProcessor(_exportedActivities))
+            .Build();
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        _tracerProvider?.Dispose();
+    }
+
+    [TestMethod]
+    public async Task SimpleChat_ProcessorReceivesSpanWithExpectedAttributes()
+    {
+        SkipIfNoCredentials();
+
+        var chatClient = CreateChatClient();
+        var messages = new List<ChatMessage>
+        {
+            new SystemChatMessage("You are a helpful assistant. Reply in one sentence."),
+            new UserChatMessage("What is the capital of France?")
+        };
+
+        await chatClient.CompleteChatAsync(messages);
+
+        // Force flush to ensure processor has run
+        _tracerProvider!.ForceFlush();
+
+        _exportedActivities.Should().HaveCount(1);
+        var activity = _exportedActivities[0];
+
+        DumpActivity(activity, "SimpleChat — after OpenAISpanProcessor");
+
+        // Verify the processor received a valid OpenAI span
+        activity.Source.Name.Should().StartWith("OpenAI");
+        activity.Kind.Should().Be(ActivityKind.Client);
+
+        // Attributes present after processor
+        var tags = GetTags(activity);
+        tags.Should().ContainKey("gen_ai.system").WhoseValue.Should().Be("openai");
+        tags.Should().ContainKey("gen_ai.operation.name").WhoseValue.Should().Be("chat");
+        tags.Should().ContainKey("gen_ai.request.model");
+        tags.Should().ContainKey("gen_ai.response.model");
+        tags.Should().ContainKey("gen_ai.response.id");
+        tags.Should().ContainKey("gen_ai.usage.input_tokens");
+        tags.Should().ContainKey("gen_ai.usage.output_tokens");
+        tags.Should().ContainKey("gen_ai.response.finish_reasons");
+        tags.Should().ContainKey("server.address");
+        tags.Should().ContainKey("server.port");
+
+        // Current gap: processor does not add message content
+        tags.Should().NotContainKey("gen_ai.input.messages");
+        tags.Should().NotContainKey("gen_ai.output.messages");
+    }
+
+    [TestMethod]
+    public async Task ChatWithToolCall_ProcessorReceivesToolCallSpan()
+    {
+        SkipIfNoCredentials();
+
+        var chatClient = CreateChatClient();
+        var weatherTool = ChatTool.CreateFunctionTool(
+            functionName: "get_weather",
+            functionDescription: "Get the current weather for a location",
+            functionParameters: BinaryData.FromString("""
+            {
+                "type": "object",
+                "properties": {
+                    "location": { "type": "string", "description": "City name" }
+                },
+                "required": ["location"]
+            }
+            """));
+
+        var messages = new List<ChatMessage>
+        {
+            new SystemChatMessage("You are a weather assistant. Always use the get_weather tool."),
+            new UserChatMessage("What's the weather in Seattle?")
+        };
+
+        var options = new ChatCompletionOptions { Tools = { weatherTool } };
+        await chatClient.CompleteChatAsync(messages, options);
+
+        _tracerProvider!.ForceFlush();
+
+        _exportedActivities.Should().HaveCount(1);
+        var activity = _exportedActivities[0];
+
+        DumpActivity(activity, "ChatWithToolCall — after OpenAISpanProcessor");
+
+        var tags = GetTags(activity);
+        tags.Should().ContainKey("gen_ai.operation.name").WhoseValue.Should().Be("chat");
+
+        var finishReasons = activity.GetTagItem("gen_ai.response.finish_reasons") as string[];
+        finishReasons.Should().Contain("tool_calls");
+
+        // Current gap: no message/tool call content captured
+        tags.Should().NotContainKey("gen_ai.input.messages");
+        tags.Should().NotContainKey("gen_ai.output.messages");
+    }
+
+    [TestMethod]
+    public async Task ToolCallRoundTrip_ProcessorHandlesMultiTurnConversation()
+    {
+        SkipIfNoCredentials();
+
+        var chatClient = CreateChatClient();
+        var weatherTool = ChatTool.CreateFunctionTool(
+            functionName: "get_weather",
+            functionDescription: "Get the current weather for a location",
+            functionParameters: BinaryData.FromString("""
+            {
+                "type": "object",
+                "properties": {
+                    "location": { "type": "string", "description": "City name" }
+                },
+                "required": ["location"]
+            }
+            """));
+
+        // First call: trigger tool call
+        var messages = new List<ChatMessage>
+        {
+            new SystemChatMessage("You are a weather assistant. Always use the get_weather tool."),
+            new UserChatMessage("What's the weather in Seattle?")
+        };
+
+        var options = new ChatCompletionOptions { Tools = { weatherTool } };
+        var response1 = await chatClient.CompleteChatAsync(messages, options);
+        response1.Value.ToolCalls.Should().NotBeEmpty("model should request tool call");
+
+        _exportedActivities.Clear();
+
+        // Second call: provide tool response and get final answer
+        var assistantMessage = new AssistantChatMessage(response1.Value);
+        var toolCallId = response1.Value.ToolCalls[0].Id;
+        var toolResponse = new ToolChatMessage(toolCallId, "Sunny, 72°F, light breeze from the west");
+
+        var followUp = new List<ChatMessage>
+        {
+            new SystemChatMessage("You are a weather assistant."),
+            new UserChatMessage("What's the weather in Seattle?"),
+            assistantMessage,
+            toolResponse
+        };
+
+        await chatClient.CompleteChatAsync(followUp);
+
+        _tracerProvider!.ForceFlush();
+
+        _exportedActivities.Should().HaveCount(1);
+        var activity = _exportedActivities[0];
+
+        DumpActivity(activity, "ToolCallRoundTrip — after OpenAISpanProcessor");
+
+        var tags = GetTags(activity);
+        tags.Should().ContainKey("gen_ai.operation.name").WhoseValue.Should().Be("chat");
+        tags.Should().ContainKey("gen_ai.usage.input_tokens");
+        tags.Should().ContainKey("gen_ai.usage.output_tokens");
+
+        var finishReasons = activity.GetTagItem("gen_ai.response.finish_reasons") as string[];
+        finishReasons.Should().Contain("stop");
+
+        // Current gap: multi-turn messages with tool call/response not captured
+        tags.Should().NotContainKey("gen_ai.input.messages");
+        tags.Should().NotContainKey("gen_ai.output.messages");
+    }
+
+    #region Helpers
+
+    private ChatClient CreateChatClient()
+    {
+        var client = new AzureOpenAIClient(
+            new Uri(Endpoint!),
+            new ApiKeyCredential(ApiKey!));
+        return client.GetChatClient(Deployment!);
+    }
+
+    private static void SkipIfNoCredentials()
+    {
+        if (!HasCredentials)
+        {
+            Assert.Inconclusive(
+                "Skipped: set AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_API_KEY, AZURE_OPENAI_DEPLOYMENT env vars to run.");
+        }
+    }
+
+    private static Dictionary<string, object?> GetTags(Activity activity)
+    {
+        return activity.TagObjects.ToDictionary(t => t.Key, t => t.Value);
+    }
+
+    private static void DumpActivity(Activity activity, string label)
+    {
+        Console.WriteLine($"\n=== {label} ===");
+        Console.WriteLine($"  Source: {activity.Source.Name}  Kind: {activity.Kind}  Duration: {activity.Duration}");
+
+        Console.WriteLine("  Attributes:");
+        foreach (var tag in activity.TagObjects)
+            Console.WriteLine($"    {tag.Key} = {FormatValue(tag.Value)}");
+
+        if (activity.Events.Any())
+        {
+            Console.WriteLine($"  Events ({activity.Events.Count()}):");
+            foreach (var ev in activity.Events)
+            {
+                Console.WriteLine($"    '{ev.Name}'");
+                foreach (var attr in ev.Tags)
+                    Console.WriteLine($"      {attr.Key} = {FormatValue(attr.Value)}");
+            }
+        }
+
+        Console.WriteLine("===\n");
+    }
+
+    private static string FormatValue(object? value)
+    {
+        string val = value switch
+        {
+            string s => s,
+            string[] arr => $"[{string.Join(", ", arr)}]",
+            null => "(null)",
+            _ => value.ToString() ?? "(null)"
+        };
+
+        if (val.Length > 120)
+        {
+            try
+            {
+                var doc = JsonDocument.Parse(val);
+                val = "\n      " + JsonSerializer.Serialize(doc.RootElement, JsonPrint).Replace("\n", "\n      ");
+            }
+            catch { }
+        }
+
+        return val;
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// Processor that captures activities after all prior processors have run.
+/// Placed last in the processor chain to see the final enriched span.
+/// </summary>
+internal sealed class ActivityCapturingProcessor : BaseProcessor<Activity>
+{
+    private readonly List<Activity> _activities;
+
+    public ActivityCapturingProcessor(List<Activity> activities) => _activities = activities;
+
+    public override void OnEnd(Activity data)
+    {
+        _activities.Add(data);
+    }
+}

--- a/src/Tests/Microsoft.Agents.A365.Observability.Extensions.IntegrationTests/SemanticKernelSpanProcessorTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Extensions.IntegrationTests/SemanticKernelSpanProcessorTests.cs
@@ -1,0 +1,328 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.ClientModel;
+using System.Diagnostics;
+using System.Text.Json;
+using Azure.AI.OpenAI;
+using FluentAssertions;
+using Microsoft.Agents.A365.Observability.Extensions.SemanticKernel;
+using Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+
+namespace Microsoft.Agents.A365.Observability.Extensions.IntegrationTests;
+
+/// <summary>
+/// Integration tests for <see cref="SemanticKernelSpanProcessor"/> running against real Azure OpenAI
+/// via Semantic Kernel's <see cref="IChatCompletionService"/>.
+/// Pipeline: SK SDK → TracerProvider → SemanticKernelSpanProcessor → captured spans.
+/// Requires: AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_API_KEY, AZURE_OPENAI_DEPLOYMENT env vars.
+/// </summary>
+[TestClass]
+public class SemanticKernelSpanProcessorTests
+{
+    private static readonly JsonSerializerOptions JsonPrint = new() { WriteIndented = true };
+
+    private static string? Endpoint => Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT");
+    private static string? ApiKey => Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY");
+    private static string? Deployment => Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT");
+
+    private static bool HasCredentials =>
+        !string.IsNullOrEmpty(Endpoint) &&
+        !string.IsNullOrEmpty(ApiKey) &&
+        !string.IsNullOrEmpty(Deployment);
+
+    private List<Activity> _exportedActivities = new();
+    private TracerProvider? _tracerProvider;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        // Enable SK sensitive content telemetry (emits gen_ai.user.message / gen_ai.choice events)
+        AppContext.SetSwitch("Microsoft.SemanticKernel.Experimental.GenAI.EnableOTelDiagnosticsSensitive", true);
+
+        _exportedActivities = new List<Activity>();
+
+        // Wire up: SK source → SemanticKernelSpanProcessor → capture
+        _tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource("Microsoft.SemanticKernel*")
+            .AddProcessor(new SemanticKernelSpanProcessor())
+            .AddProcessor(new ActivityCapturingProcessor(_exportedActivities))
+            .Build();
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        _tracerProvider?.Dispose();
+    }
+
+    [TestMethod]
+    public async Task SimpleChat_ProcessorSetsInputAndOutputMessages()
+    {
+        SkipIfNoCredentials();
+
+        var kernel = CreateKernel();
+        var chatService = kernel.GetRequiredService<IChatCompletionService>();
+
+        var history = new ChatHistory();
+        history.AddSystemMessage("You are a helpful assistant. Reply in one sentence.");
+        history.AddUserMessage("What is the capital of France?");
+
+        var response = await chatService.GetChatMessageContentAsync(history);
+
+        _tracerProvider!.ForceFlush();
+
+        // Find the chat completion span (SK may emit multiple spans)
+        var chatSpan = _exportedActivities.FirstOrDefault(a =>
+        {
+            var op = a.GetTagItem(OpenTelemetryConstants.GenAiOperationNameKey) as string;
+            return op == "Chat" || op == "chat" || op == "chat.completions";
+        });
+
+        chatSpan.Should().NotBeNull("SK should emit a chat completion span");
+        DumpActivity(chatSpan!, "SK SimpleChat — after SemanticKernelSpanProcessor");
+
+        var tags = GetTags(chatSpan!);
+
+        // Processor should rename operation to "Chat"
+        tags.Should().ContainKey("gen_ai.operation.name");
+
+        // Processor should produce versioned A365 input messages
+        tags.Should().ContainKey("gen_ai.input.messages",
+            "SemanticKernelSpanProcessor should map input events to A365 versioned format");
+
+        var inputMessages = tags["gen_ai.input.messages"] as string;
+        inputMessages.Should().Contain("\"version\":\"0.1.0\"", "should use A365 versioned wrapper");
+        inputMessages.Should().Contain("capital of France", "should contain user message text");
+        inputMessages.Should().Contain("\"type\":\"text\"", "should use TextPart format");
+        inputMessages.Should().Contain("\"role\":\"system\"", "should include system message");
+        inputMessages.Should().Contain("\"role\":\"user\"", "should include user message");
+
+        // Processor should produce versioned A365 output messages
+        tags.Should().ContainKey("gen_ai.output.messages",
+            "SemanticKernelSpanProcessor should map choice events to A365 versioned format");
+
+        var outputMessages = tags["gen_ai.output.messages"] as string;
+        outputMessages.Should().Contain("\"version\":\"0.1.0\"", "should use A365 versioned wrapper");
+        outputMessages.Should().Contain("\"type\":\"text\"", "should use TextPart format");
+        outputMessages.Should().Contain("\"role\":\"assistant\"", "should have assistant role");
+        outputMessages.Should().Contain("\"finish_reason\":\"stop\"", "should map SK Stop → stop");
+
+        // Verify standard attributes are present
+        tags.Should().ContainKey("gen_ai.request.model");
+        tags.Should().ContainKey("gen_ai.usage.input_tokens");
+        tags.Should().ContainKey("gen_ai.usage.output_tokens");
+
+        // Dump all activities for visibility
+        Console.WriteLine($"\n  All captured activities ({_exportedActivities.Count}):");
+        foreach (var act in _exportedActivities)
+        {
+            var op = act.GetTagItem(OpenTelemetryConstants.GenAiOperationNameKey) as string ?? "(none)";
+            Console.WriteLine($"    {act.Source.Name} | {act.DisplayName} | op={op}");
+        }
+    }
+
+    [TestMethod]
+    public async Task ChatWithToolCall_ProcessorHandlesToolCallSpan()
+    {
+        SkipIfNoCredentials();
+
+        var kernel = CreateKernel();
+        kernel.Plugins.AddFromFunctions("Weather",
+        [
+            KernelFunctionFactory.CreateFromMethod(
+                ([System.ComponentModel.Description("City name")] string location) =>
+                    $"Sunny, 72°F in {location}",
+                "GetWeather",
+                "Get the current weather for a location")
+        ]);
+
+        var chatService = kernel.GetRequiredService<IChatCompletionService>();
+
+        var history = new ChatHistory();
+        history.AddSystemMessage("You are a weather assistant. Use the GetWeather function when asked about weather.");
+        history.AddUserMessage("What's the weather in Seattle?");
+
+        var settings = new AzureOpenAIPromptExecutionSettings
+        {
+            FunctionChoiceBehavior = FunctionChoiceBehavior.Auto()
+        };
+
+        var response = await chatService.GetChatMessageContentAsync(history, settings, kernel);
+
+        _tracerProvider!.ForceFlush();
+
+        // Dump all spans
+        Console.WriteLine($"\n  All captured activities ({_exportedActivities.Count}):");
+        foreach (var act in _exportedActivities)
+        {
+            var op = act.GetTagItem(OpenTelemetryConstants.GenAiOperationNameKey) as string ?? "(none)";
+            Console.WriteLine($"    {act.Source.Name} | {act.DisplayName} | op={op}");
+            DumpActivity(act, $"SK ToolCall — {act.DisplayName}");
+        }
+
+        // Find the chat span
+        var chatSpan = _exportedActivities.FirstOrDefault(a =>
+        {
+            var op = a.GetTagItem(OpenTelemetryConstants.GenAiOperationNameKey) as string;
+            return op == "Chat" || op == "chat" || op == "chat.completions";
+        });
+
+        chatSpan.Should().NotBeNull("SK should emit a chat completion span");
+
+        var tags = GetTags(chatSpan!);
+
+        // Input messages should be in versioned format with tool call parts
+        tags.Should().ContainKey("gen_ai.input.messages");
+        var inputMessages = tags["gen_ai.input.messages"] as string;
+        inputMessages.Should().Contain("\"version\":\"0.1.0\"");
+        inputMessages.Should().Contain("\"role\":\"user\"");
+        inputMessages.Should().Contain("weather");
+
+        // The last chat span (after tool response) should have full round-trip in input
+        var lastChatSpan = _exportedActivities.LastOrDefault(a =>
+        {
+            var op = a.GetTagItem(OpenTelemetryConstants.GenAiOperationNameKey) as string;
+            return op == "Chat";
+        });
+
+        if (lastChatSpan != null)
+        {
+            var lastTags = GetTags(lastChatSpan);
+            var lastInput = lastTags["gen_ai.input.messages"] as string;
+            lastInput.Should().Contain("\"type\":\"tool_call\"",
+                "assistant tool call request should be mapped as ToolCallRequestPart");
+            lastInput.Should().Contain("\"type\":\"tool_call_response\"",
+                "tool response should be mapped as ToolCallResponsePart");
+            lastInput.Should().Contain("GetWeather", "should contain function name");
+
+            var lastOutput = lastTags["gen_ai.output.messages"] as string;
+            lastOutput.Should().Contain("\"version\":\"0.1.0\"");
+            lastOutput.Should().Contain("\"finish_reason\":\"stop\"");
+        }
+
+        tags.Should().ContainKey("gen_ai.usage.input_tokens");
+    }
+
+    [TestMethod]
+    public async Task SimpleChat_SpanEventsContainMessageContent()
+    {
+        SkipIfNoCredentials();
+
+        var kernel = CreateKernel();
+        var chatService = kernel.GetRequiredService<IChatCompletionService>();
+
+        var history = new ChatHistory();
+        history.AddUserMessage("Say hello");
+
+        var response = await chatService.GetChatMessageContentAsync(history);
+
+        _tracerProvider!.ForceFlush();
+
+        // Find chat span and examine raw events before processor
+        var chatSpan = _exportedActivities.FirstOrDefault(a =>
+        {
+            var op = a.GetTagItem(OpenTelemetryConstants.GenAiOperationNameKey) as string;
+            return op == "Chat" || op == "chat" || op == "chat.completions";
+        });
+
+        chatSpan.Should().NotBeNull();
+
+        // SK emits events — log them to see the format
+        Console.WriteLine($"\n  Span events ({chatSpan!.Events.Count()}):");
+        foreach (var ev in chatSpan.Events)
+        {
+            Console.WriteLine($"    Event: '{ev.Name}'");
+            foreach (var attr in ev.Tags)
+            {
+                string val = FormatValue(attr.Value);
+                Console.WriteLine($"      {attr.Key} = {val}");
+            }
+        }
+
+        // SK should emit gen_ai.user.message and gen_ai.choice events
+        var eventNames = chatSpan.Events.Select(e => e.Name).ToList();
+        eventNames.Should().Contain("gen_ai.user.message",
+            "SK should emit user message events when sensitive diagnostics are enabled");
+        eventNames.Should().Contain("gen_ai.choice",
+            "SK should emit choice events when sensitive diagnostics are enabled");
+    }
+
+    #region Helpers
+
+    private Kernel CreateKernel()
+    {
+        var builder = Kernel.CreateBuilder();
+        builder.AddAzureOpenAIChatCompletion(
+            deploymentName: Deployment!,
+            endpoint: Endpoint!,
+            apiKey: ApiKey!);
+        return builder.Build();
+    }
+
+    private static void SkipIfNoCredentials()
+    {
+        if (!HasCredentials)
+        {
+            Assert.Inconclusive(
+                "Skipped: set AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_API_KEY, AZURE_OPENAI_DEPLOYMENT env vars to run.");
+        }
+    }
+
+    private static Dictionary<string, object?> GetTags(Activity activity)
+    {
+        return activity.TagObjects.ToDictionary(t => t.Key, t => t.Value);
+    }
+
+    private static void DumpActivity(Activity activity, string label)
+    {
+        Console.WriteLine($"\n=== {label} ===");
+        Console.WriteLine($"  Source: {activity.Source.Name}  Kind: {activity.Kind}  Duration: {activity.Duration}");
+
+        Console.WriteLine("  Attributes:");
+        foreach (var tag in activity.TagObjects)
+            Console.WriteLine($"    {tag.Key} = {FormatValue(tag.Value)}");
+
+        if (activity.Events.Any())
+        {
+            Console.WriteLine($"  Events ({activity.Events.Count()}):");
+            foreach (var ev in activity.Events)
+            {
+                Console.WriteLine($"    '{ev.Name}'");
+                foreach (var attr in ev.Tags)
+                    Console.WriteLine($"      {attr.Key} = {FormatValue(attr.Value)}");
+            }
+        }
+        Console.WriteLine("===\n");
+    }
+
+    private static string FormatValue(object? value)
+    {
+        string val = value switch
+        {
+            string s => s,
+            string[] arr => $"[{string.Join(", ", arr)}]",
+            null => "(null)",
+            _ => value.ToString() ?? "(null)"
+        };
+
+        if (val.Length > 120)
+        {
+            try
+            {
+                var doc = JsonDocument.Parse(val);
+                val = "\n      " + JsonSerializer.Serialize(doc.RootElement, JsonPrint).Replace("\n", "\n      ");
+            }
+            catch { }
+        }
+
+        return val;
+    }
+
+    #endregion
+}

--- a/src/Tests/Microsoft.Agents.A365.Observability.Extensions.IntegrationTests/SemanticKernelSpanProcessorTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Extensions.IntegrationTests/SemanticKernelSpanProcessorTests.cs
@@ -1,10 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.ClientModel;
 using System.Diagnostics;
 using System.Text.Json;
-using Azure.AI.OpenAI;
 using FluentAssertions;
 using Microsoft.Agents.A365.Observability.Extensions.SemanticKernel;
 using Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes;
@@ -73,7 +71,7 @@ public class SemanticKernelSpanProcessorTests
         history.AddSystemMessage("You are a helpful assistant. Reply in one sentence.");
         history.AddUserMessage("What is the capital of France?");
 
-        var response = await chatService.GetChatMessageContentAsync(history);
+        _ = await chatService.GetChatMessageContentAsync(history);
 
         _tracerProvider!.ForceFlush();
 
@@ -153,7 +151,7 @@ public class SemanticKernelSpanProcessorTests
             FunctionChoiceBehavior = FunctionChoiceBehavior.Auto()
         };
 
-        var response = await chatService.GetChatMessageContentAsync(history, settings, kernel);
+        _ = await chatService.GetChatMessageContentAsync(history, settings, kernel);
 
         _tracerProvider!.ForceFlush();
 
@@ -220,7 +218,7 @@ public class SemanticKernelSpanProcessorTests
         var history = new ChatHistory();
         history.AddUserMessage("Say hello");
 
-        var response = await chatService.GetChatMessageContentAsync(history);
+        _ = await chatService.GetChatMessageContentAsync(history);
 
         _tracerProvider!.ForceFlush();
 


### PR DESCRIPTION
**Task**
Support the new messaging format for auto instrumentation

Note - auto instrumentation for openai does not generate input and output messages.
**Add integration for auto instrumentation to ensure the mapping works**

**Result**
Note the versioned JSON string for input and output messages with auto instrumentation integration test

SK from integration test
```
 {
   "gen_ai.operation.name": "Chat",
   "gen_ai.system": "openai",
   "gen_ai.request.model": "gpt-4o-mini",
   "gen_ai.usage.input_tokens": 29,
   "gen_ai.usage.output_tokens": 8,
   "gen_ai.response.finish_reason": ["Stop"],
   "gen_ai.response.id": "chatcmpl-DUEUo39ghvTQkAC17gYJ1HliSKuMl",
   "gen_ai.input.messages": "{\"version\":\"0.1.0\",\"messages\":[{\"role\":\"system\",\"parts\":[{\"type\":\"text\",\"content\":\"You are a 
helpful assistant. Reply in one sentence.\"}]},{\"role\":\"user\",\"parts\":[{\"type\":\"text\",\"content\":\"What is the capital of 
France?\"}]}]}",
   "gen_ai.output.messages": 
"{\"version\":\"0.1.0\",\"messages\":[{\"finish_reason\":\"stop\",\"role\":\"assistant\",\"parts\":[{\"type\":\"text\",\"content\":\"The capital
 of France is Paris.\"}]}]}"
 }
```

From Agent Framework

```

   {
     "gen_ai.operation.name": "chat",
     "gen_ai.request.model": "gpt-4o-mini",
     "gen_ai.provider.name": "openai",
     "server.address": "a365-hw-openai-sentinel.openai.azure.com",
     "server.port": 443,
     "gen_ai.input.messages": "{\"version\":\"0.1.0\",\"messages\":[{\"role\":\"system\",\"parts\":[{\"type\":\"text\",\"content\":\"You are a 
  helpful assistant. Reply in one sentence.\"}]},{\"role\":\"user\",\"parts\":[{\"type\":\"text\",\"content\":\"What is the capital of 
  France?\"}]}]}",
     "gen_ai.output.messages": 
  "{\"version\":\"0.1.0\",\"messages\":[{\"finish_reason\":\"stop\",\"role\":\"assistant\",\"parts\":[{\"type\":\"text\",\"content\":\"The capital
   of France is Paris.\"}]}]}",
     "gen_ai.response.finish_reasons": ["stop"],
     "gen_ai.response.id": "chatcmpl-DUEUndrviaSaOzcxi9jIOILq8RLkq",
     "gen_ai.response.model": "gpt-4o-mini-2024-07-18",
     "gen_ai.usage.input_tokens": 29,
     "gen_ai.usage.output_tokens": 8
   }
```