### PR TITLE
Update prod scopes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,18 @@ Exceptions:
 ### Legacy References
 - **Never** use the keyword "Kairo" in any code - this is legacy terminology that must be replaced
 
+### Observability Export Configuration — Coordinated Review Required
+
+The following three constants must stay in sync. If a PR changes **any one** of them, the reviewer (human or Copilot) **must** ask the author to confirm the other two are still correct:
+
+| Constant | Location |
+|---|---|
+| `ProdObservabilityScope` | `src/Observability/Runtime/Common/EnvironmentUtils.cs` (accessed via `GetObservabilityAuthenticationScope()`) |
+| `DefaultEndpointHost` | `src/Observability/Runtime/Tracing/Exporters/Agent365ExporterOptions.cs` |
+| Export URL path pattern | `BuildEndpointPath()` in `src/Observability/Runtime/Tracing/Exporters/Agent365ExporterCore.cs` |
+
+Snapshot tests in `src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/Tracing/Exporters/ExportConfigConsistencyTests.cs` will fail if any value drifts, but the developer must also verify the values are correct for the target environment — the tests only catch accidental drift, not intentional-but-incomplete updates.
+
 ### Pre-Commit Requirements
 Before committing changes, ensure:
 1. The solution builds: `dotnet build src/Microsoft.Agents.A365.Sdk.sln`

--- a/src/Observability/Runtime/Common/EnvironmentUtils.cs
+++ b/src/Observability/Runtime/Common/EnvironmentUtils.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Common
     /// </summary>
     public class EnvironmentUtils
     {
-        private const string ProdObservabilityScope = "https://api.powerplatform.com/.default";
+        private const string ProdObservabilityScope = "api://9b975845-388f-4429-889e-eab1ef63949c/Agent365.Observability.OtelWrite";
         private const string ProdObservabilityClusterCategory = "prod";
         private const string DevelopmentEnvironmentName = "development";
 

--- a/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/Common/EnvironmentUtilsTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/Common/EnvironmentUtilsTests.cs
@@ -45,6 +45,6 @@ public class EnvironmentUtilsTests
         // Assert
         Assert.IsNotNull(scopes);
         Assert.AreEqual(1, scopes.Length);
-        Assert.AreEqual("https://api.powerplatform.com/.default", scopes[0]);
+        Assert.AreEqual("api://9b975845-388f-4429-889e-eab1ef63949c/Agent365.Observability.OtelWrite", scopes[0]);
     }
 }

--- a/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/Tracing/Exporters/ExportConfigConsistencyTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/Tracing/Exporters/ExportConfigConsistencyTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using FluentAssertions;
+using Microsoft.Agents.A365.Observability.Runtime.Common;
+using Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Microsoft.Agents.A365.Observability.Runtime.Tests.Tracing.Exporters;
+
+/// <summary>
+/// Cross-constant consistency test for observability export configuration.
+///
+/// Three production constants must stay in sync: the auth scope
+/// (<c>ProdObservabilityScope</c>), the default endpoint host
+/// (<c>DefaultEndpointHost</c>), and the export URL path pattern
+/// (<c>BuildEndpointPath</c>). This test pins all three together so that
+/// changing any one forces a review of the others. Individual value tests
+/// already exist in <c>EnvironmentUtilsTests</c> and <c>Agent365ExporterTests</c>;
+/// this test adds the cross-cutting invariant they don't cover.
+/// </summary>
+[TestClass]
+public sealed class ExportConfigConsistencyTests
+{
+    private const string ScopeOverrideEnvVar = "A365_OBSERVABILITY_SCOPE_OVERRIDE";
+
+    // Pinned production values — update ALL of these together when any one changes.
+    private const string ExpectedScope = "api://9b975845-388f-4429-889e-eab1ef63949c/Agent365.Observability.OtelWrite";
+    private const string ExpectedStandardUri = "https://agent365.svc.cloud.microsoft/observability/tenants/t1/otlp/agents/a1/traces?api-version=1";
+    private const string ExpectedS2SUr = "https://agent365.svc.cloud.microsoft/observabilityService/tenants/t1/otlp/agents/a1/traces?api-version=1";
+
+    [TestInitialize]
+    public void TestInitialize() => Environment.SetEnvironmentVariable(ScopeOverrideEnvVar, null);
+
+    [TestCleanup]
+    public void TestCleanup() => Environment.SetEnvironmentVariable(ScopeOverrideEnvVar, null);
+
+    [TestMethod]
+    public void ExportConfig_Scope_Endpoint_And_Paths_AreConsistent()
+    {
+        // Auth scope
+        var scopes = EnvironmentUtils.GetObservabilityAuthenticationScope();
+        scopes.Should().ContainSingle()
+            .Which.Should().Be(ExpectedScope,
+                "ProdObservabilityScope changed — also review DefaultEndpointHost and BuildEndpointPath.");
+
+        // Full URIs (standard + S2S) combining DefaultEndpointHost + BuildEndpointPath + BuildRequestUri
+        var core = new Agent365ExporterCore(
+            new ExportFormatter(NullLogger<ExportFormatter>.Instance),
+            NullLogger<Agent365ExporterCore>.Instance);
+
+        var standardUri = core.BuildRequestUri(
+            Agent365ExporterOptions.DefaultEndpointHost,
+            core.BuildEndpointPath("t1", "a1", useS2SEndpoint: false));
+
+        var s2sUri = core.BuildRequestUri(
+            Agent365ExporterOptions.DefaultEndpointHost,
+            core.BuildEndpointPath("t1", "a1", useS2SEndpoint: true));
+
+        standardUri.Should().Be(ExpectedStandardUri,
+            "Standard export URI changed — also review ProdObservabilityScope and DefaultEndpointHost.");
+
+        s2sUri.Should().Be(ExpectedS2SUr,
+            "S2S export URI changed — also review ProdObservabilityScope and DefaultEndpointHost.");
+
+        // Coarse sanity: scope targets Agent365 Observability, endpoint targets agent365 service
+        scopes[0].Should().Contain("Agent365.Observability");
+        Agent365ExporterOptions.DefaultEndpointHost.Should().Contain("agent365");
+    }
+}


### PR DESCRIPTION
This pull request updates the default observability authentication scope used in the `EnvironmentUtils` class and its associated unit test. The main change is to align the authentication scope with a new resource identifier.

**Authentication scope update:**

* Changed the default value of `ProdObservabilityScope` in `EnvironmentUtils` to use the new resource identifier (`api://9b975845-388f-4429-889e-eab1ef63949c/Agent365.Observability.OtelWrite`) instead of the previous URL (`https://api.powerplatform.com/.default`).
* Updated the corresponding unit test in `EnvironmentUtilsTests` to expect the new default authentication scope value.