### PR TITLE
Switch DebugType from embedded to portable for symbol server support

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -43,7 +43,7 @@
     <!-- Source Link Support -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <DebugType>embedded</DebugType>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <!-- Package references for all projects -->


### PR DESCRIPTION
## Summary
Changes `DebugType` from `embedded` to `portable` in `Directory.Build.props` so that separate `.pdb` files are produced alongside assemblies.

## Motivation
Enables uploading debug symbols to a symbol server. With `embedded`, PDB data lives inside the DLL and cannot be extracted. With `portable`, standalone `.pdb` files are generated.

## Details
- Existing `IncludeSymbols=true` and `SymbolPackageFormat=snupkg` settings now correctly package PDBs into `.snupkg` symbol packages
- Debugging is unaffected — debuggers auto-load `.pdb` files from the same directory as the DLL
- Build and all tests pass with this change