### PR TITLE
Add OTLP payload byte-size chunking to Agent365Exporter

### DIFF
--- a/src/Observability/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
+++ b/src/Observability/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
@@ -225,10 +225,9 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
                         "Agent365ExporterCore: Sending chunk {ChunkIndex} of {ChunkCount} ({SpanCount} spans, {BodyBytes} bytes) to {RequestUri}.",
                         i + 1, chunks.Count, chunk.Count, bodyBytes, requestUri);
 
-                    HttpResponseMessage? resp = null;
                     try
                     {
-                        resp = await sendAsync(request).ConfigureAwait(false);
+                        using var resp = await sendAsync(request).ConfigureAwait(false);
                         var correlationId = resp.Headers.Contains(CorrelationIdHeaderKey) ? resp.Headers.GetValues(CorrelationIdHeaderKey).FirstOrDefault() : null;
                         this._logger?.LogDebug("Agent365ExporterCore: HTTP {StatusCode} exporting spans. '{HeaderKey}': '{CorrelationId}'.", (int)resp.StatusCode, CorrelationIdHeaderKey, correlationId);
                         if (!resp.IsSuccessStatusCode)
@@ -239,14 +238,15 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
                             return ExportResult.Failure;
                         }
                     }
-                    catch (Exception ex)
+                    catch (HttpRequestException ex)
                     {
                         this._logger?.LogError(ex, "Agent365ExporterCore: Exception exporting spans.");
                         return ExportResult.Failure;
                     }
-                    finally
+                    catch (TaskCanceledException ex)
                     {
-                        resp?.Dispose();
+                        this._logger?.LogError(ex, "Agent365ExporterCore: Exception exporting spans.");
+                        return ExportResult.Failure;
                     }
                 }
             }

--- a/src/Observability/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
+++ b/src/Observability/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
@@ -166,8 +166,21 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
             foreach (var g in groups)
             {
                 var (tenantId, agentId, activities) = g;
-                var json = _formatter.FormatMany(activities, resource);
-                using var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+                // Split the per-identity batch into byte-size chunks under MaxPayloadBytes.
+                // Per-span truncation already caps individual spans at 250 KB; this provides
+                // batch-level enforcement of the 1 MB server limit.
+                var chunks = PayloadChunking.ChunkBySize(
+                    activities,
+                    PayloadChunking.EstimateActivityBytes,
+                    options.MaxPayloadBytes);
+
+                if (chunks.Count > 1)
+                {
+                    this._logger?.LogInformation(
+                        "Agent365ExporterCore: Split {SpanCount} spans into {ChunkCount} chunks for tenantId {TenantId}, agentId {AgentId}.",
+                        activities.Count, chunks.Count, tenantId, agentId);
+                }
 
                 var endpointOverride = Environment.GetEnvironmentVariable("A365_OBSERVABILITY_DOMAIN_OVERRIDE");
                 var endpoint = !string.IsNullOrEmpty(endpointOverride)
@@ -176,11 +189,6 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
 
                 var endpointPath = BuildEndpointPath(tenantId, agentId, options.UseS2SEndpoint);
                 var requestUri = BuildRequestUri(endpoint, endpointPath);
-
-                using var request = new HttpRequestMessage(HttpMethod.Post, requestUri)
-                {
-                    Content = content
-                };
 
                 string? token = null;
                 try
@@ -193,34 +201,53 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
                     this._logger?.LogError(ex, "Agent365ExporterCore: TokenResolver threw for agent {AgentId} tenant {TenantId}.", agentId, tenantId);
                 }
 
-                if (!string.IsNullOrEmpty(token))
-                {
-                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-                }
-                else
+                if (string.IsNullOrEmpty(token))
                 {
                     this._logger?.LogWarning("Agent365ExporterCore: No token obtained. Skipping export for this identity.");
                     return ExportResult.Failure;
                 }
-                    
-                HttpResponseMessage? resp = null;
-                try
+
+                // Send each chunk; all-or-nothing: fail on first chunk failure so the batch processor retries.
+                for (int i = 0; i < chunks.Count; i++)
                 {
-                    this._logger?.LogDebug("Agent365ExporterCore: Sending {SpanCount} spans to {RequestUri}.", activities.Count, requestUri);
-                    resp = await sendAsync(request).ConfigureAwait(false);
-                    var correlationId = resp.Headers.Contains(CorrelationIdHeaderKey) ? resp.Headers.GetValues(CorrelationIdHeaderKey).FirstOrDefault() : null;
-                    this._logger?.LogDebug("Agent365ExporterCore: HTTP {StatusCode} exporting spans. '{HeaderKey}': '{CorrelationId}'.", (int)resp.StatusCode, CorrelationIdHeaderKey, correlationId);
-                    if (!resp.IsSuccessStatusCode)
+                    var chunk = chunks[i];
+                    var json = _formatter.FormatMany(chunk, resource);
+                    using var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+                    using var request = new HttpRequestMessage(HttpMethod.Post, requestUri)
+                    {
+                        Content = content
+                    };
+                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+                    var bodyBytes = Encoding.UTF8.GetByteCount(json);
+                    this._logger?.LogDebug(
+                        "Agent365ExporterCore: Sending chunk {ChunkIndex} of {ChunkCount} ({SpanCount} spans, {BodyBytes} bytes) to {RequestUri}.",
+                        i + 1, chunks.Count, chunk.Count, bodyBytes, requestUri);
+
+                    HttpResponseMessage? resp = null;
+                    try
+                    {
+                        resp = await sendAsync(request).ConfigureAwait(false);
+                        var correlationId = resp.Headers.Contains(CorrelationIdHeaderKey) ? resp.Headers.GetValues(CorrelationIdHeaderKey).FirstOrDefault() : null;
+                        this._logger?.LogDebug("Agent365ExporterCore: HTTP {StatusCode} exporting spans. '{HeaderKey}': '{CorrelationId}'.", (int)resp.StatusCode, CorrelationIdHeaderKey, correlationId);
+                        if (!resp.IsSuccessStatusCode)
+                        {
+                            this._logger?.LogWarning(
+                                "Agent365ExporterCore: Chunk {ChunkIndex} of {ChunkCount} failed; aborting batch.",
+                                i + 1, chunks.Count);
+                            return ExportResult.Failure;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        this._logger?.LogError(ex, "Agent365ExporterCore: Exception exporting spans.");
                         return ExportResult.Failure;
-                }
-                catch (Exception ex)
-                {
-                    this._logger?.LogError(ex, "Agent365ExporterCore: Exception exporting spans.");
-                    return ExportResult.Failure;
-                }
-                finally
-                {
-                    resp?.Dispose();
+                    }
+                    finally
+                    {
+                        resp?.Dispose();
+                    }
                 }
             }
             return ExportResult.Success;

--- a/src/Observability/Runtime/Tracing/Exporters/Agent365ExporterOptions.cs
+++ b/src/Observability/Runtime/Tracing/Exporters/Agent365ExporterOptions.cs
@@ -86,5 +86,13 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
         /// Default is 512.
         /// </summary>
         public int MaxExportBatchSize { get; set; } = 512;
+
+        /// <summary>
+        /// Upper bound on HTTP request body size in bytes used by per-request payload chunking.
+        /// 100 KB headroom under the 1 MB server limit accounts for estimator error and JSON/envelope
+        /// overhead (for example, resource attributes and scope wrappers).
+        /// Default is 900,000 bytes.
+        /// </summary>
+        public long MaxPayloadBytes { get; set; } = 900_000;
     }
 }

--- a/src/Observability/Runtime/Tracing/Exporters/PayloadChunking.cs
+++ b/src/Observability/Runtime/Tracing/Exporters/PayloadChunking.cs
@@ -1,0 +1,176 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
+{
+    /// <summary>
+    /// Heuristic span size estimation and byte-level chunking for OTLP/HTTP JSON payloads.
+    ///
+    /// The Agent 365 OTLP traces endpoint enforces a 1 MB request body limit. Per-span
+    /// truncation (250 KB cap inside <see cref="Common.ExportFormatter"/>) prevents any
+    /// single span from being too large; this class provides the second layer of defense
+    /// at the batch level by splitting batches into sub-batches whose cumulative estimated
+    /// size stays under <see cref="Agent365ExporterOptions.MaxPayloadBytes"/>.
+    /// </summary>
+    public static class PayloadChunking
+    {
+        /// <summary>
+        /// Overhead constant for OTLP JSON span fixed fields
+        /// (traceId, spanId, parentSpanId, kind, timestamps, status, scope wrapper, etc.).
+        /// Intentionally generous to account for serializer variance.
+        /// </summary>
+        private const int SpanBaseOverhead = 2000;
+
+        /// <summary>
+        /// Overhead per attribute in OTLP JSON format. Covers key/value JSON wrapping overhead.
+        /// </summary>
+        private const int AttrOverhead = 80;
+
+        /// <summary>
+        /// Overhead per event in OTLP JSON.
+        /// </summary>
+        private const int EventOverhead = 200;
+
+        /// <summary>
+        /// Estimates the serialized byte size of a single attribute value in OTLP/HTTP JSON.
+        /// </summary>
+        /// <param name="value">The attribute value to estimate.</param>
+        /// <returns>An over-estimate of the serialized size in bytes.</returns>
+        public static long EstimateValueBytes(object? value)
+        {
+            if (value is string s)
+            {
+                return 40 + Encoding.UTF8.GetByteCount(s);
+            }
+
+            if (value is IEnumerable enumerable && !(value is string))
+            {
+                long count = 0;
+                bool firstIsString = false;
+                long stringSum = 0;
+                bool sawAny = false;
+                foreach (var item in enumerable)
+                {
+                    if (!sawAny)
+                    {
+                        firstIsString = item is string;
+                        sawAny = true;
+                    }
+                    if (firstIsString)
+                    {
+                        stringSum += 40 + Encoding.UTF8.GetByteCount(item?.ToString() ?? string.Empty);
+                    }
+                    count++;
+                }
+
+                if (count == 0) return 60;
+                if (firstIsString) return 60 + stringSum;
+                return 60 + 50 * count;
+            }
+
+            return 40; // bool/int/float/null/other
+        }
+
+        /// <summary>
+        /// Heuristic estimator for the serialized size of an OTLP span produced from the
+        /// supplied <see cref="Activity"/> when emitted as OTLP/HTTP JSON.
+        ///
+        /// Uses generous constants tuned to over-estimate by ~25-50%, providing headroom
+        /// for JSON serializer variance (whitespace, enum representation, integer-as-string).
+        /// </summary>
+        /// <param name="activity">The activity to estimate.</param>
+        /// <returns>An over-estimate of the serialized OTLP span size in bytes.</returns>
+        public static long EstimateActivityBytes(Activity activity)
+        {
+            if (activity is null) throw new ArgumentNullException(nameof(activity));
+
+            long total = SpanBaseOverhead;
+
+            if (!string.IsNullOrEmpty(activity.DisplayName))
+            {
+                total += Encoding.UTF8.GetByteCount(activity.DisplayName);
+            }
+
+            foreach (var tag in activity.TagObjects)
+            {
+                total += AttrOverhead;
+                total += Encoding.UTF8.GetByteCount(tag.Key ?? string.Empty);
+                total += EstimateValueBytes(tag.Value);
+            }
+
+            if (activity.Events != null)
+            {
+                foreach (var ev in activity.Events)
+                {
+                    total += EventOverhead;
+                    total += Encoding.UTF8.GetByteCount(ev.Name ?? string.Empty);
+                    if (ev.Tags != null)
+                    {
+                        foreach (var tag in ev.Tags)
+                        {
+                            total += AttrOverhead;
+                            total += Encoding.UTF8.GetByteCount(tag.Key ?? string.Empty);
+                            total += EstimateValueBytes(tag.Value);
+                        }
+                    }
+                }
+            }
+
+            return total;
+        }
+
+        /// <summary>
+        /// Splits items into sub-batches whose cumulative estimated size stays under
+        /// <paramref name="maxChunkBytes"/>.
+        ///
+        /// Invariants:
+        /// <list type="bullet">
+        ///   <item><description>Input order is preserved across chunks.</description></item>
+        ///   <item><description>Empty input produces empty output.</description></item>
+        ///   <item><description>A single item whose size exceeds <paramref name="maxChunkBytes"/>
+        ///   forms its own single-item chunk (never silently dropped).</description></item>
+        ///   <item><description>No chunk is ever empty.</description></item>
+        /// </list>
+        /// </summary>
+        /// <typeparam name="T">Item type.</typeparam>
+        /// <param name="items">The items to chunk.</param>
+        /// <param name="getSize">Estimator function returning approximate serialized byte size of one item.</param>
+        /// <param name="maxChunkBytes">Upper bound on cumulative estimated size per chunk.</param>
+        /// <returns>An ordered list of non-empty chunks.</returns>
+        public static List<List<T>> ChunkBySize<T>(IEnumerable<T> items, Func<T, long> getSize, long maxChunkBytes)
+        {
+            if (items is null) throw new ArgumentNullException(nameof(items));
+            if (getSize is null) throw new ArgumentNullException(nameof(getSize));
+
+            var chunks = new List<List<T>>();
+            var current = new List<T>();
+            long currentBytes = 0;
+
+            foreach (var item in items)
+            {
+                long itemBytes = getSize(item);
+                if (current.Count > 0 && currentBytes + itemBytes > maxChunkBytes)
+                {
+                    chunks.Add(current);
+                    current = new List<T>();
+                    currentBytes = 0;
+                }
+                current.Add(item);
+                currentBytes += itemBytes;
+            }
+
+            if (current.Count > 0)
+            {
+                chunks.Add(current);
+            }
+
+            return chunks;
+        }
+    }
+}

--- a/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/Tracing/Exporters/PayloadChunkingTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/Tracing/Exporters/PayloadChunkingTests.cs
@@ -12,7 +12,7 @@ public sealed class PayloadChunkingTests
 {
     private static Activity CreateActivity(string displayName, IDictionary<string, object?>? tags = null)
     {
-        var listener = new ActivityListener
+        using var listener = new ActivityListener
         {
             ShouldListenTo = source => source.Name == "Agent365Sdk.Test.Chunking",
             Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
@@ -21,7 +21,7 @@ public sealed class PayloadChunkingTests
         };
         ActivitySource.AddActivityListener(listener);
 
-        var source = new ActivitySource("Agent365Sdk.Test.Chunking");
+        using var source = new ActivitySource("Agent365Sdk.Test.Chunking");
         var activity = source.StartActivity(displayName, ActivityKind.Client)
             ?? throw new InvalidOperationException("Failed to start activity.");
         if (tags != null)

--- a/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/Tracing/Exporters/PayloadChunkingTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/Tracing/Exporters/PayloadChunkingTests.cs
@@ -1,0 +1,188 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using FluentAssertions;
+using Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters;
+using System.Diagnostics;
+
+namespace Microsoft.Agents.A365.Observability.Tests.Tracing.Exporters;
+
+[TestClass]
+public sealed class PayloadChunkingTests
+{
+    private static Activity CreateActivity(string displayName, IDictionary<string, object?>? tags = null)
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Agent365Sdk.Test.Chunking",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStarted = _ => { },
+            ActivityStopped = _ => { }
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var source = new ActivitySource("Agent365Sdk.Test.Chunking");
+        var activity = source.StartActivity(displayName, ActivityKind.Client)
+            ?? throw new InvalidOperationException("Failed to start activity.");
+        if (tags != null)
+        {
+            foreach (var kvp in tags)
+            {
+                activity.SetTag(kvp.Key, kvp.Value);
+            }
+        }
+        activity.Stop();
+        return activity;
+    }
+
+    // -----------------------------------------------------------------------
+    // EstimateValueBytes
+    // -----------------------------------------------------------------------
+
+    [TestMethod]
+    public void EstimateValueBytes_String_ReturnsHeaderPlusUtf8ByteCount()
+    {
+        PayloadChunking.EstimateValueBytes("hello").Should().Be(40 + 5);
+    }
+
+    [TestMethod]
+    public void EstimateValueBytes_EmptyArray_ReturnsBaseOverhead()
+    {
+        PayloadChunking.EstimateValueBytes(Array.Empty<string>()).Should().Be(60);
+    }
+
+    [TestMethod]
+    public void EstimateValueBytes_StringArray_SumsPerElementOverhead()
+    {
+        PayloadChunking.EstimateValueBytes(new[] { "a", "bb" })
+            .Should().Be(60 + (40 + 1) + (40 + 2));
+    }
+
+    [TestMethod]
+    public void EstimateValueBytes_NumericArray_UsesFlatPerElementCost()
+    {
+        PayloadChunking.EstimateValueBytes(new[] { 1, 2 }).Should().Be(60 + 50 * 2);
+    }
+
+    [TestMethod]
+    public void EstimateValueBytes_Scalars_ReturnsScalarOverhead()
+    {
+        PayloadChunking.EstimateValueBytes(true).Should().Be(40);
+        PayloadChunking.EstimateValueBytes(42).Should().Be(40);
+        PayloadChunking.EstimateValueBytes(null).Should().Be(40);
+    }
+
+    // -----------------------------------------------------------------------
+    // EstimateActivityBytes
+    // -----------------------------------------------------------------------
+
+    [TestMethod]
+    public void EstimateActivityBytes_GrowsWithAttributeContent()
+    {
+        var small = CreateActivity("test", new Dictionary<string, object?> { ["key"] = "val" });
+        var large = CreateActivity("test", new Dictionary<string, object?> { ["key"] = new string('x', 10_000) });
+
+        PayloadChunking.EstimateActivityBytes(large)
+            .Should().BeGreaterThan(PayloadChunking.EstimateActivityBytes(small));
+    }
+
+    [TestMethod]
+    public void EstimateActivityBytes_OverEstimatesActualJsonSize()
+    {
+        // A representative span: many attributes including some large strings.
+        var attrs = new Dictionary<string, object?>
+        {
+            ["gen_ai.system"] = "openai",
+            ["gen_ai.tool.arguments"] = new string('x', 1000),
+            ["gen_ai.tool.call_result"] = new string('y', 1000),
+        };
+        var activity = CreateActivity("test", attrs);
+
+        // The estimator targets the eventual OTLP JSON span shape (with traceId, spanId,
+        // status, scope wrapper, etc.). A simple Dictionary serialization is a strict
+        // lower bound, so the estimate should comfortably exceed it.
+        var dictJson = System.Text.Json.JsonSerializer.Serialize(attrs);
+        var actualLowerBound = System.Text.Encoding.UTF8.GetByteCount(dictJson);
+
+        PayloadChunking.EstimateActivityBytes(activity)
+            .Should().BeGreaterThan(actualLowerBound);
+    }
+
+    [TestMethod]
+    public void EstimateActivityBytes_NullActivity_Throws()
+    {
+        var act = () => PayloadChunking.EstimateActivityBytes(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    // -----------------------------------------------------------------------
+    // ChunkBySize
+    // -----------------------------------------------------------------------
+
+    [TestMethod]
+    public void ChunkBySize_EmptyInput_ReturnsEmptyOutput()
+    {
+        var result = PayloadChunking.ChunkBySize(Array.Empty<int>(), x => x, 900_000);
+        result.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void ChunkBySize_SmallItemsFitInOneChunk()
+    {
+        var items = Enumerable.Range(0, 10).Select(i => 100).ToList();
+        var chunks = PayloadChunking.ChunkBySize(items, x => x, 900_000);
+        chunks.Should().HaveCount(1);
+        chunks[0].Should().HaveCount(10);
+    }
+
+    [TestMethod]
+    public void ChunkBySize_SplitsWhenCumulativeExceedsLimitAndPreservesOrder()
+    {
+        var items = Enumerable.Range(0, 5).Select(i => (Id: $"s{i}", Size: 300_000L)).ToList();
+        var chunks = PayloadChunking.ChunkBySize(items, x => x.Size, 900_000);
+        chunks.Count.Should().BeGreaterOrEqualTo(2);
+        chunks.SelectMany(c => c).Select(x => x.Id)
+            .Should().Equal("s0", "s1", "s2", "s3", "s4");
+    }
+
+    [TestMethod]
+    public void ChunkBySize_OversizeSingleItemGetsItsOwnChunk()
+    {
+        var chunks = PayloadChunking.ChunkBySize(
+            new[] { (Id: "big", Size: 2_000_000L) },
+            x => x.Size,
+            900_000);
+        chunks.Should().HaveCount(1);
+        chunks[0][0].Id.Should().Be("big");
+    }
+
+    [TestMethod]
+    public void ChunkBySize_MultiItemChunksRespectLimitAndAreNonEmpty()
+    {
+        var items = Enumerable.Range(0, 5).Select(i => (Id: $"s{i}", Size: 200_000L)).ToList();
+        var chunks = PayloadChunking.ChunkBySize(items, x => x.Size, 500_000);
+
+        foreach (var chunk in chunks)
+        {
+            chunk.Count.Should().BeGreaterThan(0);
+            if (chunk.Count > 1)
+            {
+                chunk.Sum(x => x.Size).Should().BeLessOrEqualTo(500_000);
+            }
+        }
+    }
+
+    [TestMethod]
+    public void ChunkBySize_NullItems_Throws()
+    {
+        var act = () => PayloadChunking.ChunkBySize<int>(null!, x => x, 100);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [TestMethod]
+    public void ChunkBySize_NullGetSize_Throws()
+    {
+        var act = () => PayloadChunking.ChunkBySize<int>(new[] { 1 }, null!, 100);
+        act.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
A365 OTLP traces endpoint enforces a 1 MB request body limit. The exporter previously batched by span count (512) with no byte-level enforcement, so batches of gen-AI spans could exceed 1 MB and get rejected (403/502/500).

This adds two layers of defense:

- Heuristic span size estimator (EstimateActivityBytes) with generous over-estimation

- Byte-size chunking (ChunkBySize) that splits per-identity batches into sub-batches under MaxPayloadBytes (default 900 KB, configurable via Agent365ExporterOptions)

- All-or-nothing semantics: if any chunk fails, the entire batch fails and the BatchExportProcessor retries

Per-span truncation (250 KB cap in ExportFormatter) already existed; this complements it at the batch level.

Mirrors Agent365-nodejs PR #237 (commit e05b3b6a).

Work item: AB#37661002