### PR TITLE
[.Net] Fix gen_ai.tool.arguments attribute name to gen_ai.tool.call.arguments

### DIFF
--- a/src/Observability/Runtime/Tracing/Scopes/OpenTelemetryConstants.cs
+++ b/src/Observability/Runtime/Tracing/Scopes/OpenTelemetryConstants.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
         /// <summary>
         /// The GenAI tool arguments key.
         /// </summary>
-        public const string GenAiToolArgumentsKey = "gen_ai.tool.arguments";
+        public const string GenAiToolArgumentsKey = "gen_ai.tool.call.arguments";
         
         /// <summary>
         /// The GenAI tool type key.

--- a/src/Observability/Runtime/Tracing/Scopes/OpenTelemetryConstants.cs
+++ b/src/Observability/Runtime/Tracing/Scopes/OpenTelemetryConstants.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
         public const string GenAiToolDescriptionKey = "gen_ai.tool.description";
         
         /// <summary>
-        /// The GenAI tool arguments key.
+        /// The GenAI tool call arguments key.
         /// </summary>
         public const string GenAiToolArgumentsKey = "gen_ai.tool.call.arguments";
         

--- a/src/Tests/Microsoft.Agents.A365.Observability.Runtime.IntegrationTests/Agent365ExporterAsyncE2ETests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Runtime.IntegrationTests/Agent365ExporterAsyncE2ETests.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tests.IntegrationTests
             this.GetAttribute(attributes, "microsoft.a365.agent.blueprint.id").Should().Be(expectedAgentDetails.AgentBlueprintId);
             this.GetAttribute(attributes, "microsoft.tenant.id").Should().Be(expectedAgentDetails.TenantId);
             this.GetAttribute(attributes, "gen_ai.tool.name").Should().Be(toolCallDetails.ToolName);
-            this.GetAttribute(attributes, "gen_ai.tool.arguments").Should().Be(toolCallDetails.Arguments);
+            this.GetAttribute(attributes, "gen_ai.tool.call.arguments").Should().Be(toolCallDetails.Arguments);
             this.GetAttribute(attributes, "gen_ai.tool.call.id").Should().Be(toolCallDetails.ToolCallId);
             this.GetAttribute(attributes, "gen_ai.tool.description").Should().Be(toolCallDetails.Description);
             this.GetAttribute(attributes, "gen_ai.tool.type").Should().Be(toolCallDetails.ToolType);

--- a/src/Tests/Microsoft.Agents.A365.Observability.Runtime.IntegrationTests/Agent365ExporterE2ETests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Runtime.IntegrationTests/Agent365ExporterE2ETests.cs
@@ -192,7 +192,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tests.IntegrationTests
             this.GetAttribute(attributes, "microsoft.a365.agent.blueprint.id").Should().Be(expectedAgentDetails.AgentBlueprintId);
             this.GetAttribute(attributes, "microsoft.tenant.id").Should().Be(expectedAgentDetails.TenantId);
             this.GetAttribute(attributes, "gen_ai.tool.name").Should().Be(toolCallDetails.ToolName);
-            this.GetAttribute(attributes, "gen_ai.tool.arguments").Should().Be(toolCallDetails.Arguments);
+            this.GetAttribute(attributes, "gen_ai.tool.call.arguments").Should().Be(toolCallDetails.Arguments);
             this.GetAttribute(attributes, "gen_ai.tool.call.id").Should().Be(toolCallDetails.ToolCallId);
             this.GetAttribute(attributes, "gen_ai.tool.description").Should().Be(toolCallDetails.Description);
             this.GetAttribute(attributes, "gen_ai.tool.type").Should().Be(toolCallDetails.ToolType);
@@ -502,7 +502,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tests.IntegrationTests
                 {
                     foundExecuteTool = true;
                     // Should be truncated
-                    var args = this.GetAttribute(attrs, "gen_ai.tool.arguments");
+                    var args = this.GetAttribute(attrs, "gen_ai.tool.call.arguments");
                     args.Should().Be("TRUNCATED");
                 }
             }

--- a/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/Common/ExportFormatterTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/Common/ExportFormatterTests.cs
@@ -525,7 +525,7 @@ public void FormatMany_DoesNothing_WhenUnderLimit()
 {
     // Arrange
     using var activity = CreateActivity("tenant-1", "agent-1");
-    activity.SetTag("gen_ai.tool.arguments", new string('a', 1024)); // 1KB
+    activity.SetTag("gen_ai.tool.call.arguments", new string('a', 1024)); // 1KB
     var resource = ResourceBuilder.CreateEmpty().Build();
     var logs = new List<string>();
     var formatter = new ExportFormatter(new ListLogger<ExportFormatter>(logs));
@@ -538,7 +538,7 @@ public void FormatMany_DoesNothing_WhenUnderLimit()
     var resourceSpans = doc.RootElement.GetProperty("resourceSpans");
     var scopeSpans = resourceSpans[0].GetProperty("scopeSpans");
     var span = scopeSpans[0].GetProperty("spans")[0];
-    span.GetProperty("attributes").GetProperty("gen_ai.tool.arguments").GetString().Should().NotBe("TRUNCATED");
+    span.GetProperty("attributes").GetProperty("gen_ai.tool.call.arguments").GetString().Should().NotBe("TRUNCATED");
     logs.Should().NotContain(l => l.Contains("Truncated"));
 }
 
@@ -547,7 +547,7 @@ public void FormatMany_TruncatesSingleLargeKey()
 {
     // Arrange
     using var activity = CreateActivity("tenant-1", "agent-2");
-    activity.SetTag("gen_ai.tool.arguments", new string('b', 300 * 1024)); // 300KB
+    activity.SetTag("gen_ai.tool.call.arguments", new string('b', 300 * 1024)); // 300KB
     var resource = ResourceBuilder.CreateEmpty().Build();
     var logs = new List<string>();
     var formatter = new ExportFormatter(new ListLogger<ExportFormatter>(logs));
@@ -560,9 +560,9 @@ public void FormatMany_TruncatesSingleLargeKey()
     var resourceSpans = doc.RootElement.GetProperty("resourceSpans");
     var scopeSpans = resourceSpans[0].GetProperty("scopeSpans");
     var span = scopeSpans[0].GetProperty("spans")[0];
-    span.GetProperty("attributes").GetProperty("gen_ai.tool.arguments").GetString().Should().Be("TRUNCATED");
-    logs.Should().Contain(l => l.Contains("Key 'gen_ai.tool.arguments' size = "));
-    logs.Should().Contain(l => l.Contains("Truncated 'gen_ai.tool.arguments'"));
+    span.GetProperty("attributes").GetProperty("gen_ai.tool.call.arguments").GetString().Should().Be("TRUNCATED");
+    logs.Should().Contain(l => l.Contains("Key 'gen_ai.tool.call.arguments' size = "));
+    logs.Should().Contain(l => l.Contains("Truncated 'gen_ai.tool.call.arguments'"));
 }
 
 [TestMethod]
@@ -570,7 +570,7 @@ public void FormatMany_TruncatesMultipleKeys_LargestFirst()
 {
     // Arrange
     using var activity = CreateActivity("tenant-1", "agent-1");
-    activity.SetTag("gen_ai.tool.arguments", new string('c', 200 * 1024));
+    activity.SetTag("gen_ai.tool.call.arguments", new string('c', 200 * 1024));
     activity.SetTag("gen_ai.tool.call.result", new string('d', 100 * 1024));
     var resource = ResourceBuilder.CreateEmpty().Build();
     var logs = new List<string>();
@@ -585,9 +585,9 @@ public void FormatMany_TruncatesMultipleKeys_LargestFirst()
     var scopeSpans = resourceSpans[0].GetProperty("scopeSpans");
     var span = scopeSpans[0].GetProperty("spans")[0];
     var attr = span.GetProperty("attributes");
-    attr.GetProperty("gen_ai.tool.arguments").GetString().Should().Be("TRUNCATED");
-    logs.Should().Contain(l => l.Contains("Truncated 'gen_ai.tool.arguments'"));
-    logs.Should().Contain(l => l.Contains("Key 'gen_ai.tool.arguments' size = "));
+    attr.GetProperty("gen_ai.tool.call.arguments").GetString().Should().Be("TRUNCATED");
+    logs.Should().Contain(l => l.Contains("Truncated 'gen_ai.tool.call.arguments'"));
+    logs.Should().Contain(l => l.Contains("Key 'gen_ai.tool.call.arguments' size = "));
     logs.Should().Contain(l => l.Contains("Key 'gen_ai.tool.call.result' size = "));
 }
 
@@ -596,7 +596,7 @@ public void FormatMany_LogsAllKeySizes()
 {
     // Arrange
     using var activity = CreateActivity("tenant-1", "agent-1");
-    activity.SetTag("gen_ai.tool.arguments", new string('x', 100 * 1024));
+    activity.SetTag("gen_ai.tool.call.arguments", new string('x', 100 * 1024));
     activity.SetTag("gen_ai.tool.call.result", new string('y', 125 * 1024));
     activity.SetTag("gen_ai.input.messages", new string('z', 75 * 1024));
     activity.SetTag("gen_ai.agent.invocation_input", new string('z', 0));
@@ -610,7 +610,7 @@ public void FormatMany_LogsAllKeySizes()
     formatter.FormatMany(new[] { activity }, resource);
 
     // Assert
-    logs.Should().Contain(l => l.Contains("Key 'gen_ai.tool.arguments' size = 100"));
+    logs.Should().Contain(l => l.Contains("Key 'gen_ai.tool.call.arguments' size = 100"));
     logs.Should().Contain(l => l.Contains("Key 'gen_ai.tool.call.result' size = 125"));
     logs.Should().Contain(l => l.Contains("Key 'gen_ai.input.messages' size = 75"));
     logs.Should().Contain(l => l.Contains("Key 'gen_ai.agent.invocation_input' size = 0"));

--- a/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/Tracing/Exporters/PayloadChunkingTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/Tracing/Exporters/PayloadChunkingTests.cs
@@ -93,8 +93,8 @@ public sealed class PayloadChunkingTests
         var attrs = new Dictionary<string, object?>
         {
             ["gen_ai.system"] = "openai",
-            ["gen_ai.tool.arguments"] = new string('x', 1000),
-            ["gen_ai.tool.call_result"] = new string('y', 1000),
+            ["gen_ai.tool.call.arguments"] = new string('x', 1000),
+            ["gen_ai.tool.call.result"] = new string('y', 1000),
         };
         var activity = CreateActivity("test", attrs);
 


### PR DESCRIPTION
## Summary
- Renames `gen_ai.tool.arguments` to `gen_ai.tool.call.arguments` to align with OpenTelemetry GenAI semantic conventions
- Fixes `gen_ai.tool.call_result` to `gen_ai.tool.call.result` in PayloadChunkingTests
- Mirrors [microsoft/opentelemetry-distro-dotnet#88](https://github.com/microsoft/opentelemetry-distro-dotnet/pull/88)

## Test plan
- [x] Solution builds with zero warnings/errors
- [x] All 301 observability runtime tests pass
- [x] All 11 integration tests pass
- [ ] Verify exported telemetry uses the correct `gen_ai.tool.call.arguments` attribute name

🤖 Generated with [Claude Code](https://claude.com/claude-code)