### PR TITLE
fix: add product context fallback for subchannels

### DIFF
--- a/src/Observability/Hosting/Extensions/TurnContextExtensions.cs
+++ b/src/Observability/Hosting/Extensions/TurnContextExtensions.cs
@@ -71,7 +71,30 @@ namespace Microsoft.Agents.A365.Observability.Hosting.Extensions
         public static IEnumerable<KeyValuePair<string, object?>> GetChannelBaggagePairs(this ITurnContext turnContext)
         {
             yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.ChannelNameKey, turnContext.Activity?.ChannelId?.Channel);
-            yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.ChannelLinkKey, turnContext.Activity?.ChannelId?.SubChannel);
+            
+            // Try to get SubChannel from ChannelId first, then fall back to productContext in ChannelData
+            var subChannel = turnContext.Activity?.ChannelId?.SubChannel;
+            if (string.IsNullOrWhiteSpace(subChannel) && turnContext.Activity?.ChannelData != null)
+            {
+                try
+                {
+                    var channelDataJson = turnContext.Activity.ChannelData.ToString();
+                    if (!string.IsNullOrWhiteSpace(channelDataJson))
+                    {
+                        using var doc = System.Text.Json.JsonDocument.Parse(channelDataJson);
+                        if (doc.RootElement.TryGetProperty("productContext", out var productContextElem) &&
+                            productContextElem.ValueKind == System.Text.Json.JsonValueKind.String)
+                        {
+                            subChannel = productContextElem.GetString();
+                        }
+                    }
+                }
+                catch
+                {
+                }
+            }
+            
+            yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.ChannelLinkKey, subChannel);
         }
 
         /// <summary>

--- a/src/Observability/Hosting/Extensions/TurnContextExtensions.cs
+++ b/src/Observability/Hosting/Extensions/TurnContextExtensions.cs
@@ -89,9 +89,9 @@ namespace Microsoft.Agents.A365.Observability.Hosting.Extensions
                         }
                     }
                 }
-                catch (System.Text.Json.JsonException)
+                catch
                 {
-                    // Ignore malformed ChannelData and keep subChannel fallback behavior.
+                    // Ignore ChannelData parsing failures and keep subChannel fallback behavior.
                 }
             }
             

--- a/src/Observability/Hosting/Extensions/TurnContextExtensions.cs
+++ b/src/Observability/Hosting/Extensions/TurnContextExtensions.cs
@@ -89,8 +89,9 @@ namespace Microsoft.Agents.A365.Observability.Hosting.Extensions
                         }
                     }
                 }
-                catch
+                catch (System.Text.Json.JsonException)
                 {
+                    // Ignore malformed ChannelData and keep subChannel fallback behavior.
                 }
             }
             

--- a/src/Tests/Microsoft.Agents.A365.Observability.Hosting.Tests/Middleware/BaggageTurnMiddlewareTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Hosting.Tests/Middleware/BaggageTurnMiddlewareTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Agents.Builder;
 using Microsoft.Agents.Core.Models;
 using Moq;
 using OpenTelemetry;
+using System.Text.Json;
 
 namespace Microsoft.Agents.A365.Observability.Hosting.Tests.Middleware;
 
@@ -309,6 +310,101 @@ public class BaggageTurnMiddlewareTests
 
         // Assert - SubChannel should take precedence, productContext should be ignored
         capturedChannelLink.Should().Be("teams-subchannel");
+    }
+
+    [TestMethod]
+    public async Task OnTurnAsync_ExtractsProductContextFromJsonStringChannelData()
+    {
+        // Arrange
+        var middleware = new BaggageTurnMiddleware();
+        
+        // Create a turn context with ChannelData as a JSON string
+        var mockActivity = new Mock<IActivity>();
+        mockActivity.Setup(a => a.Type).Returns("message");
+        mockActivity.Setup(a => a.Text).Returns("Hello");
+        mockActivity.Setup(a => a.From).Returns(new ChannelAccount
+        {
+            Id = "caller-id",
+            Name = "Caller",
+            AadObjectId = "caller-aad",
+        });
+        mockActivity.Setup(a => a.Recipient).Returns(new ChannelAccount
+        {
+            Id = "agent-id",
+            Name = "Agent",
+            TenantId = "tenant-123",
+        });
+        mockActivity.Setup(a => a.Conversation).Returns(new ConversationAccount { Id = "conv-id" });
+        mockActivity.Setup(a => a.ServiceUrl).Returns("https://example.com");
+        mockActivity.Setup(a => a.ChannelId).Returns(new ChannelId("msteams")); // No SubChannel
+        
+        // ChannelData as a JSON string (simulating deserialization from wire format)
+        var channelDataJson = """{"productContext":"COPILOT"}""";
+        mockActivity.Setup(a => a.ChannelData).Returns(channelDataJson);
+
+        var mockTurnContext = new Mock<ITurnContext>();
+        mockTurnContext.Setup(tc => tc.Activity).Returns(mockActivity.Object);
+
+        string? capturedChannelLink = null;
+
+        NextDelegate next = (ct) =>
+        {
+            capturedChannelLink = Baggage.Current.GetBaggage(OpenTelemetryConstants.ChannelLinkKey);
+            return Task.CompletedTask;
+        };
+
+        // Act
+        await middleware.OnTurnAsync(mockTurnContext.Object, next);
+
+        // Assert
+        capturedChannelLink.Should().Be("COPILOT");
+    }
+
+    [TestMethod]
+    public async Task OnTurnAsync_HandlesInvalidJsonChannelDataGracefully()
+    {
+        // Arrange
+        var middleware = new BaggageTurnMiddleware();
+        
+        // Create a turn context with ChannelData as an invalid JSON string
+        var mockActivity = new Mock<IActivity>();
+        mockActivity.Setup(a => a.Type).Returns("message");
+        mockActivity.Setup(a => a.Text).Returns("Hello");
+        mockActivity.Setup(a => a.From).Returns(new ChannelAccount
+        {
+            Id = "caller-id",
+            Name = "Caller",
+            AadObjectId = "caller-aad",
+        });
+        mockActivity.Setup(a => a.Recipient).Returns(new ChannelAccount
+        {
+            Id = "agent-id",
+            Name = "Agent",
+            TenantId = "tenant-123",
+        });
+        mockActivity.Setup(a => a.Conversation).Returns(new ConversationAccount { Id = "conv-id" });
+        mockActivity.Setup(a => a.ServiceUrl).Returns("https://example.com");
+        mockActivity.Setup(a => a.ChannelId).Returns(new ChannelId("msteams")); // No SubChannel
+        
+        // ChannelData as a non-JSON string
+        mockActivity.Setup(a => a.ChannelData).Returns("not valid json");
+
+        var mockTurnContext = new Mock<ITurnContext>();
+        mockTurnContext.Setup(tc => tc.Activity).Returns(mockActivity.Object);
+
+        string? capturedChannelLink = null;
+
+        NextDelegate next = (ct) =>
+        {
+            capturedChannelLink = Baggage.Current.GetBaggage(OpenTelemetryConstants.ChannelLinkKey);
+            return Task.CompletedTask;
+        };
+
+        // Act
+        await middleware.OnTurnAsync(mockTurnContext.Object, next);
+
+        // Assert - Should not set ChannelLink, should fail gracefully
+        capturedChannelLink.Should().BeNull();
     }
 
     private static ITurnContext CreateTurnContext(

--- a/src/Tests/Microsoft.Agents.A365.Observability.Hosting.Tests/Middleware/BaggageTurnMiddlewareTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Hosting.Tests/Middleware/BaggageTurnMiddlewareTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Agents.Builder;
 using Microsoft.Agents.Core.Models;
 using Moq;
 using OpenTelemetry;
+using System.Text.Json;
 
 namespace Microsoft.Agents.A365.Observability.Hosting.Tests.Middleware;
 
@@ -206,6 +207,109 @@ public class BaggageTurnMiddlewareTests
 
         // Assert
         capturedUserId.Should().Be("bef730f4-d6f5-4ffb-b759-26ffa449ed7e");
+    }
+
+    [TestMethod]
+    public async Task OnTurnAsync_ExtractsProductContextFromChannelData()
+    {
+        // Arrange
+        var middleware = new BaggageTurnMiddleware();
+        
+        // Create a turn context with productContext in ChannelData
+        var mockActivity = new Mock<IActivity>();
+        mockActivity.Setup(a => a.Type).Returns("message");
+        mockActivity.Setup(a => a.Text).Returns("Hello");
+        mockActivity.Setup(a => a.From).Returns(new ChannelAccount
+        {
+            Id = "caller-id",
+            Name = "Caller",
+            AadObjectId = "caller-aad",
+        });
+        mockActivity.Setup(a => a.Recipient).Returns(new ChannelAccount
+        {
+            Id = "agent-id",
+            Name = "Agent",
+            TenantId = "tenant-123",
+        });
+        mockActivity.Setup(a => a.Conversation).Returns(new ConversationAccount { Id = "conv-id" });
+        mockActivity.Setup(a => a.ServiceUrl).Returns("https://example.com");
+        mockActivity.Setup(a => a.ChannelId).Returns(new ChannelId("msteams")); // No SubChannel
+        
+        // Set up ChannelData with productContext - create a mock that returns JSON from ToString()
+        var channelDataJson = """{"productContext":"COPILOT"}""";
+        var mockChannelData = new Mock<object>();
+        mockChannelData.Setup(x => x.ToString()).Returns(channelDataJson);
+        mockActivity.Setup(a => a.ChannelData).Returns(mockChannelData.Object);
+
+        var mockTurnContext = new Mock<ITurnContext>();
+        mockTurnContext.Setup(tc => tc.Activity).Returns(mockActivity.Object);
+
+        string? capturedChannelLink = null;
+
+        NextDelegate next = (ct) =>
+        {
+            capturedChannelLink = Baggage.Current.GetBaggage(OpenTelemetryConstants.ChannelLinkKey);
+            return Task.CompletedTask;
+        };
+
+        // Act
+        await middleware.OnTurnAsync(mockTurnContext.Object, next);
+
+        // Assert
+        capturedChannelLink.Should().Be("COPILOT");
+    }
+
+    [TestMethod]
+    public async Task OnTurnAsync_SubChannelTakesPrecedenceOverProductContext()
+    {
+        // Arrange
+        var middleware = new BaggageTurnMiddleware();
+        
+        // Create a turn context with BOTH SubChannel and productContext
+        var mockActivity = new Mock<IActivity>();
+        mockActivity.Setup(a => a.Type).Returns("message");
+        mockActivity.Setup(a => a.Text).Returns("Hello");
+        mockActivity.Setup(a => a.From).Returns(new ChannelAccount
+        {
+            Id = "caller-id",
+            Name = "Caller",
+            AadObjectId = "caller-aad",
+        });
+        mockActivity.Setup(a => a.Recipient).Returns(new ChannelAccount
+        {
+            Id = "agent-id",
+            Name = "Agent",
+            TenantId = "tenant-123",
+        });
+        mockActivity.Setup(a => a.Conversation).Returns(new ConversationAccount { Id = "conv-id" });
+        mockActivity.Setup(a => a.ServiceUrl).Returns("https://example.com");
+        
+        // Set SubChannel explicitly
+        var channelId = new ChannelId("msteams") { SubChannel = "teams-subchannel" };
+        mockActivity.Setup(a => a.ChannelId).Returns(channelId);
+        
+        // Set up ChannelData with productContext (should be ignored)
+        var channelDataJson = """{"productContext":"COPILOT"}""";
+        var mockChannelData = new Mock<object>();
+        mockChannelData.Setup(x => x.ToString()).Returns(channelDataJson);
+        mockActivity.Setup(a => a.ChannelData).Returns(mockChannelData.Object);
+
+        var mockTurnContext = new Mock<ITurnContext>();
+        mockTurnContext.Setup(tc => tc.Activity).Returns(mockActivity.Object);
+
+        string? capturedChannelLink = null;
+
+        NextDelegate next = (ct) =>
+        {
+            capturedChannelLink = Baggage.Current.GetBaggage(OpenTelemetryConstants.ChannelLinkKey);
+            return Task.CompletedTask;
+        };
+
+        // Act
+        await middleware.OnTurnAsync(mockTurnContext.Object, next);
+
+        // Assert - SubChannel should take precedence, productContext should be ignored
+        capturedChannelLink.Should().Be("teams-subchannel");
     }
 
     private static ITurnContext CreateTurnContext(

--- a/src/Tests/Microsoft.Agents.A365.Observability.Hosting.Tests/Middleware/BaggageTurnMiddlewareTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Hosting.Tests/Middleware/BaggageTurnMiddlewareTests.cs
@@ -215,34 +215,12 @@ public class BaggageTurnMiddlewareTests
         // Arrange
         var middleware = new BaggageTurnMiddleware();
         
-        // Create a turn context with productContext in ChannelData
-        var mockActivity = new Mock<IActivity>();
-        mockActivity.Setup(a => a.Type).Returns("message");
-        mockActivity.Setup(a => a.Text).Returns("Hello");
-        mockActivity.Setup(a => a.From).Returns(new ChannelAccount
-        {
-            Id = "caller-id",
-            Name = "Caller",
-            AadObjectId = "caller-aad",
-        });
-        mockActivity.Setup(a => a.Recipient).Returns(new ChannelAccount
-        {
-            Id = "agent-id",
-            Name = "Agent",
-            TenantId = "tenant-123",
-        });
-        mockActivity.Setup(a => a.Conversation).Returns(new ConversationAccount { Id = "conv-id" });
-        mockActivity.Setup(a => a.ServiceUrl).Returns("https://example.com");
-        mockActivity.Setup(a => a.ChannelId).Returns(new ChannelId("msteams")); // No SubChannel
-        
         // Set up ChannelData with productContext - create a mock that returns JSON from ToString()
         var channelDataJson = """{"productContext":"COPILOT"}""";
         var mockChannelData = new Mock<object>();
         mockChannelData.Setup(x => x.ToString()).Returns(channelDataJson);
-        mockActivity.Setup(a => a.ChannelData).Returns(mockChannelData.Object);
-
-        var mockTurnContext = new Mock<ITurnContext>();
-        mockTurnContext.Setup(tc => tc.Activity).Returns(mockActivity.Object);
+        
+        var turnContext = CreateTurnContext(channelData: mockChannelData.Object);
 
         string? capturedChannelLink = null;
 
@@ -253,7 +231,7 @@ public class BaggageTurnMiddlewareTests
         };
 
         // Act
-        await middleware.OnTurnAsync(mockTurnContext.Object, next);
+        await middleware.OnTurnAsync(turnContext, next);
 
         // Assert
         capturedChannelLink.Should().Be("COPILOT");
@@ -265,37 +243,14 @@ public class BaggageTurnMiddlewareTests
         // Arrange
         var middleware = new BaggageTurnMiddleware();
         
-        // Create a turn context with BOTH SubChannel and productContext
-        var mockActivity = new Mock<IActivity>();
-        mockActivity.Setup(a => a.Type).Returns("message");
-        mockActivity.Setup(a => a.Text).Returns("Hello");
-        mockActivity.Setup(a => a.From).Returns(new ChannelAccount
-        {
-            Id = "caller-id",
-            Name = "Caller",
-            AadObjectId = "caller-aad",
-        });
-        mockActivity.Setup(a => a.Recipient).Returns(new ChannelAccount
-        {
-            Id = "agent-id",
-            Name = "Agent",
-            TenantId = "tenant-123",
-        });
-        mockActivity.Setup(a => a.Conversation).Returns(new ConversationAccount { Id = "conv-id" });
-        mockActivity.Setup(a => a.ServiceUrl).Returns("https://example.com");
-        
-        // Set SubChannel explicitly
-        var channelId = new ChannelId("msteams") { SubChannel = "teams-subchannel" };
-        mockActivity.Setup(a => a.ChannelId).Returns(channelId);
-        
         // Set up ChannelData with productContext (should be ignored)
         var channelDataJson = """{"productContext":"COPILOT"}""";
         var mockChannelData = new Mock<object>();
         mockChannelData.Setup(x => x.ToString()).Returns(channelDataJson);
-        mockActivity.Setup(a => a.ChannelData).Returns(mockChannelData.Object);
-
-        var mockTurnContext = new Mock<ITurnContext>();
-        mockTurnContext.Setup(tc => tc.Activity).Returns(mockActivity.Object);
+        
+        var turnContext = CreateTurnContext(
+            subChannel: "teams-subchannel",
+            channelData: mockChannelData.Object);
 
         string? capturedChannelLink = null;
 
@@ -306,7 +261,7 @@ public class BaggageTurnMiddlewareTests
         };
 
         // Act
-        await middleware.OnTurnAsync(mockTurnContext.Object, next);
+        await middleware.OnTurnAsync(turnContext, next);
 
         // Assert - SubChannel should take precedence, productContext should be ignored
         capturedChannelLink.Should().Be("teams-subchannel");
@@ -318,32 +273,10 @@ public class BaggageTurnMiddlewareTests
         // Arrange
         var middleware = new BaggageTurnMiddleware();
         
-        // Create a turn context with ChannelData as a JSON string
-        var mockActivity = new Mock<IActivity>();
-        mockActivity.Setup(a => a.Type).Returns("message");
-        mockActivity.Setup(a => a.Text).Returns("Hello");
-        mockActivity.Setup(a => a.From).Returns(new ChannelAccount
-        {
-            Id = "caller-id",
-            Name = "Caller",
-            AadObjectId = "caller-aad",
-        });
-        mockActivity.Setup(a => a.Recipient).Returns(new ChannelAccount
-        {
-            Id = "agent-id",
-            Name = "Agent",
-            TenantId = "tenant-123",
-        });
-        mockActivity.Setup(a => a.Conversation).Returns(new ConversationAccount { Id = "conv-id" });
-        mockActivity.Setup(a => a.ServiceUrl).Returns("https://example.com");
-        mockActivity.Setup(a => a.ChannelId).Returns(new ChannelId("msteams")); // No SubChannel
-        
         // ChannelData as a JSON string (simulating deserialization from wire format)
         var channelDataJson = """{"productContext":"COPILOT"}""";
-        mockActivity.Setup(a => a.ChannelData).Returns(channelDataJson);
-
-        var mockTurnContext = new Mock<ITurnContext>();
-        mockTurnContext.Setup(tc => tc.Activity).Returns(mockActivity.Object);
+        
+        var turnContext = CreateTurnContext(channelData: channelDataJson);
 
         string? capturedChannelLink = null;
 
@@ -354,7 +287,7 @@ public class BaggageTurnMiddlewareTests
         };
 
         // Act
-        await middleware.OnTurnAsync(mockTurnContext.Object, next);
+        await middleware.OnTurnAsync(turnContext, next);
 
         // Assert
         capturedChannelLink.Should().Be("COPILOT");
@@ -366,31 +299,7 @@ public class BaggageTurnMiddlewareTests
         // Arrange
         var middleware = new BaggageTurnMiddleware();
         
-        // Create a turn context with ChannelData as an invalid JSON string
-        var mockActivity = new Mock<IActivity>();
-        mockActivity.Setup(a => a.Type).Returns("message");
-        mockActivity.Setup(a => a.Text).Returns("Hello");
-        mockActivity.Setup(a => a.From).Returns(new ChannelAccount
-        {
-            Id = "caller-id",
-            Name = "Caller",
-            AadObjectId = "caller-aad",
-        });
-        mockActivity.Setup(a => a.Recipient).Returns(new ChannelAccount
-        {
-            Id = "agent-id",
-            Name = "Agent",
-            TenantId = "tenant-123",
-        });
-        mockActivity.Setup(a => a.Conversation).Returns(new ConversationAccount { Id = "conv-id" });
-        mockActivity.Setup(a => a.ServiceUrl).Returns("https://example.com");
-        mockActivity.Setup(a => a.ChannelId).Returns(new ChannelId("msteams")); // No SubChannel
-        
-        // ChannelData as a non-JSON string
-        mockActivity.Setup(a => a.ChannelData).Returns("not valid json");
-
-        var mockTurnContext = new Mock<ITurnContext>();
-        mockTurnContext.Setup(tc => tc.Activity).Returns(mockActivity.Object);
+        var turnContext = CreateTurnContext(channelData: "not valid json");
 
         string? capturedChannelLink = null;
 
@@ -401,7 +310,7 @@ public class BaggageTurnMiddlewareTests
         };
 
         // Act
-        await middleware.OnTurnAsync(mockTurnContext.Object, next);
+        await middleware.OnTurnAsync(turnContext, next);
 
         // Assert - Should not set ChannelLink, should fail gracefully
         capturedChannelLink.Should().BeNull();
@@ -413,7 +322,9 @@ public class BaggageTurnMiddlewareTests
         string? fromId = "caller-id",
         string? fromAadObjectId = "caller-aad",
         string? fromAgenticUserId = null,
-        string channelName = "msteams")
+        string channelName = "msteams",
+        string? subChannel = null,
+        object? channelData = null)
     {
         var mockActivity = new Mock<IActivity>();
         mockActivity.Setup(a => a.Type).Returns(activityType);
@@ -438,7 +349,20 @@ public class BaggageTurnMiddlewareTests
         });
         mockActivity.Setup(a => a.Conversation).Returns(new ConversationAccount { Id = "conv-id" });
         mockActivity.Setup(a => a.ServiceUrl).Returns("https://example.com");
-        mockActivity.Setup(a => a.ChannelId).Returns(new ChannelId(channelName));
+        
+        // Set up ChannelId with optional SubChannel
+        var channelId = new ChannelId(channelName);
+        if (subChannel != null)
+        {
+            channelId.SubChannel = subChannel;
+        }
+        mockActivity.Setup(a => a.ChannelId).Returns(channelId);
+        
+        // Set up ChannelData if provided
+        if (channelData != null)
+        {
+            mockActivity.Setup(a => a.ChannelData).Returns(channelData);
+        }
 
         var mockTurnContext = new Mock<ITurnContext>();
         mockTurnContext.Setup(tc => tc.Activity).Returns(mockActivity.Object);

--- a/src/Tests/Microsoft.Agents.A365.Observability.Hosting.Tests/Middleware/BaggageTurnMiddlewareTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Hosting.Tests/Middleware/BaggageTurnMiddlewareTests.cs
@@ -8,7 +8,6 @@ using Microsoft.Agents.Builder;
 using Microsoft.Agents.Core.Models;
 using Moq;
 using OpenTelemetry;
-using System.Text.Json;
 
 namespace Microsoft.Agents.A365.Observability.Hosting.Tests.Middleware;
 

--- a/src/Tests/Microsoft.Agents.A365.Observability.Hosting.Tests/Middleware/BaggageTurnMiddlewareTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Hosting.Tests/Middleware/BaggageTurnMiddlewareTests.cs
@@ -214,12 +214,13 @@ public class BaggageTurnMiddlewareTests
         // Arrange
         var middleware = new BaggageTurnMiddleware();
         
-        // Set up ChannelData with productContext - create a mock that returns JSON from ToString()
-        var channelDataJson = """{"productContext":"COPILOT"}""";
-        var mockChannelData = new Mock<object>();
-        mockChannelData.Setup(x => x.ToString()).Returns(channelDataJson);
+        // Set up ChannelData with productContext using a real JSON-backed object.
+        var channelData = new System.Text.Json.Nodes.JsonObject
+        {
+            ["productContext"] = "COPILOT",
+        };
         
-        var turnContext = CreateTurnContext(channelData: mockChannelData.Object);
+        var turnContext = CreateTurnContext(channelData: channelData);
 
         string? capturedChannelLink = null;
 


### PR DESCRIPTION
Previously, when the subchannel was being sent via the `productContext` property, it was not set correctly by the SDK. This fixes a bug where having `productContext`=`"COPILOT"` was causing issues with the agent activity view.

This pull request enhances how the channel "subchannel" (used for observability and tracing) is extracted from incoming activities. The code now attempts to retrieve the subchannel from the `ChannelId` property first, and if not present, falls back to extracting a `productContext` value from the `ChannelData` JSON. Additionally, new tests are added to verify this fallback logic and precedence.

Channel subchannel extraction improvements:

* Updated `GetChannelBaggagePairs` in `TurnContextExtensions.cs` to extract the subchannel from `ChannelId.SubChannel`, and if missing, parse the `productContext` from the `ChannelData` JSON. This ensures better support for channels that provide subchannel information in different locations.

Testing enhancements:

* Added a test to `BaggageTurnMiddlewareTests.cs` to verify that the middleware correctly extracts `productContext` from `ChannelData` when `SubChannel` is not present.
* Added a test to ensure that `SubChannel` from `ChannelId` takes precedence over `productContext` in `ChannelData` if both are present.
* Included necessary `System.Text.Json` import for test JSON parsing.