### PR TITLE
Mark 1.1 development as prerelease (post-GA)

### DIFF
--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.1",
+  "version": "1.1-preview",
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
Adds `-preview` suffix to the nbgv version so that packages built from `main` are published as prerelease (e.g. `1.1.5-preview`) instead of stable. This aligns dotnet with the NodeJS SDK, which made the equivalent change in PR #247. Stable `1.1.x` releases will be produced from `release/v1.1` branches.
