### PR TITLE
Replace static reserved-key allowlist with dynamic ContainsKey check for extra attributes

### DIFF
--- a/src/Observability/Runtime/DTOs/Builders/BaseDataBuilder.cs
+++ b/src/Observability/Runtime/DTOs/Builders/BaseDataBuilder.cs
@@ -14,51 +14,6 @@ namespace Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders
     /// </summary>
     public abstract class BaseDataBuilder<T> where T : BaseData
     {
-        // Reserved attribute keys managed by specific builder methods; extra attributes must NOT override these.
-        private static readonly HashSet<string> ReservedAttributeKeys = new HashSet<string>(StringComparer.Ordinal)
-        {
-            OpenTelemetryConstants.GenAiInputMessagesKey,
-            OpenTelemetryConstants.GenAiOutputMessagesKey,
-            OpenTelemetryConstants.GenAiAgentIdKey,
-            OpenTelemetryConstants.GenAiAgentNameKey,
-            OpenTelemetryConstants.GenAiAgentDescriptionKey,
-            OpenTelemetryConstants.GenAiAgentVersionKey,
-            OpenTelemetryConstants.AgentAUIDKey,
-            OpenTelemetryConstants.AgentEmailKey,
-            OpenTelemetryConstants.AgentBlueprintIdKey,
-            OpenTelemetryConstants.AgentPlatformIdKey,
-            OpenTelemetryConstants.TenantIdKey,
-            OpenTelemetryConstants.GenAiProviderNameKey,
-            OpenTelemetryConstants.ServerAddressKey,
-            OpenTelemetryConstants.ServerPortKey,
-            OpenTelemetryConstants.ChannelNameKey,
-            OpenTelemetryConstants.ChannelLinkKey,
-            OpenTelemetryConstants.UserIdKey,
-            OpenTelemetryConstants.UserEmailKey,
-            OpenTelemetryConstants.UserNameKey,
-            OpenTelemetryConstants.CallerAgentNameKey,
-            OpenTelemetryConstants.CallerAgentIdKey,
-            OpenTelemetryConstants.CallerAgentBlueprintIdKey,
-            OpenTelemetryConstants.CallerAgentAUIDKey,
-            OpenTelemetryConstants.CallerAgentEmailKey,
-            OpenTelemetryConstants.CallerAgentPlatformIdKey,
-            OpenTelemetryConstants.CallerAgentVersionKey,
-            OpenTelemetryConstants.CallerClientIpKey,
-            OpenTelemetryConstants.GenAiConversationIdKey,
-            OpenTelemetryConstants.SessionIdKey,
-            OpenTelemetryConstants.GenAiToolNameKey,
-            OpenTelemetryConstants.GenAiToolArgumentsKey,
-            OpenTelemetryConstants.GenAiToolCallIdKey,
-            OpenTelemetryConstants.GenAiToolDescriptionKey,
-            OpenTelemetryConstants.GenAiToolTypeKey,
-            OpenTelemetryConstants.GenAiToolCallResultKey,
-            OpenTelemetryConstants.GenAiOperationNameKey,
-            OpenTelemetryConstants.GenAiRequestModelKey,
-            OpenTelemetryConstants.GenAiUsageInputTokensKey,
-            OpenTelemetryConstants.GenAiUsageOutputTokensKey,
-            OpenTelemetryConstants.GenAiResponseFinishReasonsKey,
-            OpenTelemetryConstants.GenAiAgentThoughtProcessKey
-        };
 
         /// <summary>
         /// Adds attributes for input messages.
@@ -198,7 +153,8 @@ namespace Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders
         }
 
         /// <summary>
-        /// Adds extra attributes to the attributes dictionary while ignoring reserved keys.
+        /// Adds extra attributes to the attributes dictionary.
+        /// Extra attributes cannot override keys already set by the builder on this span.
         /// </summary>
         protected static void AddExtraAttributes(IDictionary<string, object?> attributes, IDictionary<string, object?>? extraAttributes)
         {
@@ -206,7 +162,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders
 
             foreach (var kvp in extraAttributes)
             {
-                if ((kvp.Value != null && !ReservedAttributeKeys.Contains(kvp.Key)))
+                if (kvp.Value != null && !attributes.ContainsKey(kvp.Key))
                 {
                     attributes[kvp.Key] = kvp.Value;
                 }

--- a/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/DTOs/Builders/InvokeAgentDataBuilderTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/DTOs/Builders/InvokeAgentDataBuilderTests.cs
@@ -430,6 +430,31 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tests.DTOs.Builders
         }
 
         [TestMethod]
+        public void Build_AllowsRequestModel_ViaExtraAttributes_WhenNotSetByBuilder()
+        {
+            // Arrange
+            var endpoint = new Uri("https://example.com");
+            var agentDetails = new AgentDetails("agent-model", "ModelAgent");
+            var scopeDetails = new InvokeAgentScopeDetails(endpoint: endpoint);
+            var conversationId = "conv-model";
+            var extras = new Dictionary<string, object?>
+            {
+                {OpenTelemetryConstants.GenAiRequestModelKey, "gpt-4o"},
+            };
+
+            // Act
+            var telemetry = InvokeAgentDataBuilder.Build(
+                scopeDetails,
+                agentDetails,
+                conversationId,
+                extraAttributes: extras);
+
+            // Assert - gen_ai.request.model is allowed because InvokeAgentDataBuilder does not set it
+            telemetry.Attributes.Should().ContainKey(OpenTelemetryConstants.GenAiRequestModelKey)
+                .WhoseValue.Should().Be("gpt-4o");
+        }
+
+        [TestMethod]
         public void Build_WithAgentPlatformId_SetsExpectedAttributes()
         {
             // Arrange


### PR DESCRIPTION
## Summary

Replaces the static \ReservedAttributeKeys\ HashSet (40 hardcoded keys) in \BaseDataBuilder\ with a dynamic \ttributes.ContainsKey()\ check.

## Motivation

The previous approach used a shared allowlist across all builders, which prevented setting attributes like \gen_ai.request.model\ on \invoke_agent\ spans — even though that builder never sets it. The new logic:

- **Allows** extra attributes to add any key the builder didn't already set on that specific span
- **Still prevents** overriding keys explicitly set by the builder (e.g., \gen_ai.request.model\ on inference spans remains protected)
- **No global allowlist to maintain** when new attributes are added

## Changes

- \src/Observability/Runtime/DTOs/Builders/BaseDataBuilder.cs\: Removed \ReservedAttributeKeys\ set; updated \AddExtraAttributes\ to use \!attributes.ContainsKey(kvp.Key)\
- Added test: \Build_AllowsRequestModel_ViaExtraAttributes_WhenNotSetByBuilder\

## Testing

All 621 tests pass (317 observability tests including the new one).