### PR TITLE
Add AsyncContextualTokenResolver for agentic user ID support in token resolution

### DIFF
--- a/src/Observability/Runtime/Tracing/Exporters/Agent365Exporter.cs
+++ b/src/Observability/Runtime/Tracing/Exporters/Agent365Exporter.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 using OpenTelemetry.Resources;
@@ -42,8 +43,8 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _options = options ?? throw new ArgumentNullException(nameof(options));
 
-            if (_options.TokenResolver == null)
-                throw new ArgumentNullException(nameof(options.TokenResolver), "Agent365ExporterOptions.TokenResolver must be provided.");
+            if (_options.TokenResolver == null && _options.ContextualTokenResolver == null)
+                throw new ArgumentNullException(nameof(options.TokenResolver), "Agent365ExporterOptions.TokenResolver or ContextualTokenResolver must be provided.");
 
             _httpClient = httpClient ?? HttpClientFactory.CreateWithTimeout(options.ExporterTimeoutMilliseconds);
             _resource = resource ?? ResourceBuilder.CreateEmpty().Build();
@@ -72,7 +73,9 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
                     groups: groups,
                     resource: _resource,
                     options: _options,
-                    tokenResolver: (agentId, tenantId) => _options.TokenResolver!(agentId, tenantId),
+                    tokenResolver: (agentId, tenantId) => _options.TokenResolver != null
+                        ? _options.TokenResolver(agentId, tenantId)
+                        : Task.FromResult<string?>(null),
                     sendAsync: request => _httpClient.SendAsync(request)
                 ).GetAwaiter().GetResult();
             }

--- a/src/Observability/Runtime/Tracing/Exporters/Agent365ExporterAsync.cs
+++ b/src/Observability/Runtime/Tracing/Exporters/Agent365ExporterAsync.cs
@@ -44,8 +44,8 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
             this._logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this._options = options ?? throw new ArgumentNullException(nameof(options));
 
-            if (_options.TokenResolver == null)
-                throw new ArgumentNullException(nameof(options.TokenResolver), "Agent365ExporterOptions.TokenResolver must be provided.");
+            if (_options.TokenResolver == null && _options.ContextualTokenResolver == null)
+                throw new ArgumentNullException(nameof(options.TokenResolver), "Agent365ExporterOptions.TokenResolver or ContextualTokenResolver must be provided.");
 
             this._httpClient = httpClient ?? HttpClientFactory.CreateWithTimeout(options.ExporterTimeoutMilliseconds);
             this._resource = resource ?? ResourceBuilder.CreateEmpty().Build();
@@ -74,7 +74,9 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
                     groups: groups,
                     resource: this._resource,
                     options: this._options,
-                    tokenResolver: (agentId, tenantId) => this._options.TokenResolver!(agentId, tenantId),
+                    tokenResolver: (agentId, tenantId) => this._options.TokenResolver != null
+                        ? this._options.TokenResolver(agentId, tenantId)
+                        : Task.FromResult<string?>(null),
                     sendAsync: request => this._httpClient.SendAsync(request, cancellationToken)
                 ).ConfigureAwait(false);
             }

--- a/src/Observability/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
+++ b/src/Observability/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
             InvokeAgentScope.OperationName,
             ExecuteToolScope.OperationName,
             OutputScope.OperationName,
+            OpenTelemetryConstants.ApplyGuardrailOperationName,
             "chat",
             nameof(InferenceOperationType.Chat),
         };
@@ -193,7 +194,23 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
                 string? token = null;
                 try
                 {
-                    token = await tokenResolver(agentId, tenantId).ConfigureAwait(false);
+                    // Prefer ContextualTokenResolver when set; extract agentic user ID from the
+                    // first activity in the group (1:1 relationship between agent and agentic user).
+                    if (options.ContextualTokenResolver != null)
+                    {
+                        var agenticUserId = activities.Count > 0
+                            ? activities[0].GetAttributeOrBaggage(OpenTelemetryConstants.AgentAUIDKey)
+                            : null;
+                        var identity = new AgentIdentity(agentId, agenticUserId);
+
+                        var context = new TokenResolverContext(identity, tenantId);
+                        token = await options.ContextualTokenResolver(context).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        token = await tokenResolver(agentId, tenantId).ConfigureAwait(false);
+                    }
+
                     this._logger?.LogDebug("Agent365ExporterCore: Obtained token for agent {AgentId} tenant {TenantId}.", agentId, tenantId);
                 }
                 catch (Exception ex)

--- a/src/Observability/Runtime/Tracing/Exporters/Agent365ExporterOptions.cs
+++ b/src/Observability/Runtime/Tracing/Exporters/Agent365ExporterOptions.cs
@@ -13,6 +13,15 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
     public delegate Task<string?> AsyncAuthTokenResolver(string agentId, string tenantId);
 
     /// <summary>
+    /// Async delegate used by the exporter to obtain an auth token using rich context.
+    /// Provides additional fields (e.g. <see cref="TokenResolverContext.Identity"/>)
+    /// beyond what <see cref="AsyncAuthTokenResolver"/> offers.
+    /// Must be fast and non-blocking (use internal caching elsewhere).
+    /// Return null/empty to omit the Authorization header.
+    /// </summary>
+    public delegate Task<string?> AsyncContextualTokenResolver(TokenResolverContext context);
+
+    /// <summary>
     /// Delegate used by the exporter to resolve the endpoint host or URL for a given tenant id.
     /// The return value may be a bare host name (e.g. "agent365.svc.cloud.microsoft") or a full URL
     /// (e.g. "https://agent365.svc.cloud.microsoft").
@@ -46,9 +55,19 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
         public string ClusterCategory { get; set; } = "production";
 
         /// <summary>
-        /// Async delegate used to resolve the auth token. REQUIRED.
+        /// Async delegate used to resolve the auth token.
+        /// Either this or <see cref="ContextualTokenResolver"/> must be set.
+        /// When both are set, <see cref="ContextualTokenResolver"/> takes precedence.
         /// </summary>
         public AsyncAuthTokenResolver? TokenResolver { get; set; }
+
+        /// <summary>
+        /// Async delegate used to resolve the auth token with rich context including the agentic user ID.
+        /// Takes precedence over <see cref="TokenResolver"/> when set.
+        /// When this resolver is active, the exporter partitions export batches by agentic user ID
+        /// in addition to tenant and agent, so each resolver call receives the correct user context.
+        /// </summary>
+        public AsyncContextualTokenResolver? ContextualTokenResolver { get; set; }
 
         /// <summary>
         /// Delegate used to resolve the endpoint host or URL for a given tenant id.

--- a/src/Observability/Runtime/Tracing/Exporters/Agent365ExporterOptions.cs
+++ b/src/Observability/Runtime/Tracing/Exporters/Agent365ExporterOptions.cs
@@ -62,10 +62,10 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
         public AsyncAuthTokenResolver? TokenResolver { get; set; }
 
         /// <summary>
-        /// Async delegate used to resolve the auth token with rich context including the agentic user ID.
+        /// Async delegate used to resolve the auth token with rich context, which may include the
+        /// agentic user ID associated with the export batch context.
         /// Takes precedence over <see cref="TokenResolver"/> when set.
-        /// When this resolver is active, the exporter partitions export batches by agentic user ID
-        /// in addition to tenant and agent, so each resolver call receives the correct user context.
+        /// The exporter does not guarantee separate batching or resolver invocation per agentic user ID.
         /// </summary>
         public AsyncContextualTokenResolver? ContextualTokenResolver { get; set; }
 

--- a/src/Observability/Runtime/Tracing/Exporters/AgentIdentity.cs
+++ b/src/Observability/Runtime/Tracing/Exporters/AgentIdentity.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
+{
+    /// <summary>
+    /// Represents the identity of an agent and its acting user.
+    /// <para>
+    /// In the AI teammate scenario, <see cref="AgenticUserId"/> is 1:1 with <see cref="AgentId"/>.
+    /// In the S2S scenario, <see cref="AgenticUserId"/> will be null.
+    /// </para>
+    /// </summary>
+    public class AgentIdentity
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentIdentity"/> class.
+        /// </summary>
+        /// <param name="agentId">The agent identifier.</param>
+        /// <param name="agenticUserId">The agentic user identifier (AAD Object ID), or null in S2S scenarios.</param>
+        public AgentIdentity(string agentId, string? agenticUserId = null)
+        {
+            AgentId = agentId;
+            AgenticUserId = agenticUserId;
+        }
+
+        /// <summary>
+        /// Gets the agent identifier.
+        /// </summary>
+        public string AgentId { get; }
+
+        /// <summary>
+        /// Gets the agentic user identifier (AAD Object ID).
+        /// In the AI teammate scenario, this value is 1:1 with <see cref="AgentId"/>.
+        /// Will be null in the S2S scenario.
+        /// </summary>
+        public string? AgenticUserId { get; }
+    }
+}

--- a/src/Observability/Runtime/Tracing/Exporters/TokenResolverContext.cs
+++ b/src/Observability/Runtime/Tracing/Exporters/TokenResolverContext.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
+{
+    /// <summary>
+    /// Provides contextual information to the token resolver delegate.
+    /// <para>
+    /// <see cref="Identity"/> provides first-class access to agent identity fields (agent ID,
+    /// agentic user ID). <see cref="TenantId"/> and <see cref="Identity"/>
+    /// together identify the cache key.
+    /// </para>
+    /// </summary>
+    public class TokenResolverContext
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TokenResolverContext"/> class.
+        /// </summary>
+        /// <param name="identity">The agent identity associated with this request.</param>
+        /// <param name="tenantId">The tenant identifier (cache key).</param>
+        public TokenResolverContext(AgentIdentity identity, string tenantId)
+        {
+            Identity = identity;
+            TenantId = tenantId;
+        }
+
+        /// <summary>
+        /// Gets the agent identity associated with this token resolution request.
+        /// Contains the agent ID and agentic user ID (AAD Object ID) as first-class properties.
+        /// </summary>
+        public AgentIdentity Identity { get; }
+
+        /// <summary>
+        /// Gets the tenant identifier (part of the cache key).
+        /// </summary>
+        public string TenantId { get; }
+    }
+}

--- a/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/Tracing/Exporters/ContextualTokenResolverTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Observability.Runtime.Tests/Tracing/Exporters/ContextualTokenResolverTests.cs
@@ -1,0 +1,345 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Agents.A365.Observability.Runtime.Common;
+using Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters;
+using Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes;
+using OpenTelemetry;
+using OpenTelemetry.Resources;
+using System.Diagnostics;
+using System.Net;
+
+namespace Microsoft.Agents.A365.Observability.Tests.Tracing.Exporters;
+
+[TestClass]
+public sealed class ContextualTokenResolverTests
+{
+    private static readonly Agent365ExporterCore Core = new(
+        new ExportFormatter(NullLogger<ExportFormatter>.Instance),
+        NullLogger<Agent365ExporterCore>.Instance);
+
+    #region AgentIdentity Tests
+
+    [TestMethod]
+    public void AgentIdentity_Constructor_SetsProperties()
+    {
+        var identity = new AgentIdentity("agent-1", "user-oid-123");
+
+        identity.AgentId.Should().Be("agent-1");
+        identity.AgenticUserId.Should().Be("user-oid-123");
+    }
+
+    [TestMethod]
+    public void AgentIdentity_Constructor_NullAgenticUserId_IsValid()
+    {
+        var identity = new AgentIdentity("agent-1");
+
+        identity.AgentId.Should().Be("agent-1");
+        identity.AgenticUserId.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void AgentIdentity_Constructor_ExplicitNull_IsValid()
+    {
+        var identity = new AgentIdentity("agent-1", null);
+
+        identity.AgentId.Should().Be("agent-1");
+        identity.AgenticUserId.Should().BeNull();
+    }
+
+    #endregion
+
+    #region TokenResolverContext Tests
+
+    [TestMethod]
+    public void TokenResolverContext_Constructor_SetsProperties()
+    {
+        var identity = new AgentIdentity("agent-1", "user-oid-123");
+        var context = new TokenResolverContext(identity, "tenant-abc");
+
+        context.Identity.Should().BeSameAs(identity);
+        context.TenantId.Should().Be("tenant-abc");
+        context.Identity.AgentId.Should().Be("agent-1");
+        context.Identity.AgenticUserId.Should().Be("user-oid-123");
+    }
+
+    [TestMethod]
+    public void TokenResolverContext_S2SScenario_NullAgenticUserId()
+    {
+        var identity = new AgentIdentity("agent-1");
+        var context = new TokenResolverContext(identity, "tenant-abc");
+
+        context.Identity.AgenticUserId.Should().BeNull();
+    }
+
+    #endregion
+
+    #region Exporter Constructor Validation Tests
+
+    [TestMethod]
+    public void Constructor_NeitherResolver_Throws()
+    {
+        var options = new Agent365ExporterOptions
+        {
+            TokenResolver = null,
+            ContextualTokenResolver = null,
+        };
+
+        Action act = () => _ = new Agent365Exporter(Core, NullLogger<Agent365Exporter>.Instance, options, null);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [TestMethod]
+    public void Constructor_OnlyTokenResolver_Succeeds()
+    {
+        var options = new Agent365ExporterOptions
+        {
+            TokenResolver = (_, _) => Task.FromResult<string?>("token"),
+        };
+
+        var exporter = new Agent365Exporter(Core, NullLogger<Agent365Exporter>.Instance, options, null);
+        exporter.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public void Constructor_OnlyContextualTokenResolver_Succeeds()
+    {
+        var options = new Agent365ExporterOptions
+        {
+            ContextualTokenResolver = ctx => Task.FromResult<string?>("token"),
+        };
+
+        var exporter = new Agent365Exporter(Core, NullLogger<Agent365Exporter>.Instance, options, null);
+        exporter.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public void Constructor_BothResolvers_Succeeds()
+    {
+        var options = new Agent365ExporterOptions
+        {
+            TokenResolver = (_, _) => Task.FromResult<string?>("legacy-token"),
+            ContextualTokenResolver = ctx => Task.FromResult<string?>("contextual-token"),
+        };
+
+        var exporter = new Agent365Exporter(Core, NullLogger<Agent365Exporter>.Instance, options, null);
+        exporter.Should().NotBeNull();
+    }
+
+    #endregion
+
+    #region ContextualTokenResolver Precedence Tests
+
+    [TestMethod]
+    public async Task ExportBatchCoreAsync_ContextualResolver_TakesPrecedence()
+    {
+        // Arrange
+        string? capturedAgentId = null;
+        string? capturedTenantId = null;
+        string? capturedAuid = null;
+        bool legacyResolverCalled = false;
+
+        var options = new Agent365ExporterOptions
+        {
+            TokenResolver = (_, _) =>
+            {
+                legacyResolverCalled = true;
+                return Task.FromResult<string?>("legacy-token");
+            },
+            ContextualTokenResolver = ctx =>
+            {
+                capturedAgentId = ctx.Identity.AgentId;
+                capturedTenantId = ctx.TenantId;
+                capturedAuid = ctx.Identity.AgenticUserId;
+                return Task.FromResult<string?>("contextual-token");
+            },
+        };
+
+        using var activity = CreateActivityWithAuid("tenant-1", "agent-1", "user-oid-123");
+        var groups = new List<(string TenantId, string AgentId, List<Activity> Activities)>
+        {
+            ("tenant-1", "agent-1", new List<Activity> { activity })
+        };
+
+        // Act
+        var result = await Core.ExportBatchCoreAsync(
+            groups,
+            ResourceBuilder.CreateEmpty().Build(),
+            options,
+            (agentId, tenantId) => options.TokenResolver!(agentId, tenantId),
+            request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+
+        // Assert
+        result.Should().Be(ExportResult.Success);
+        legacyResolverCalled.Should().BeFalse("ContextualTokenResolver should take precedence");
+        capturedAgentId.Should().Be("agent-1");
+        capturedTenantId.Should().Be("tenant-1");
+        capturedAuid.Should().Be("user-oid-123");
+    }
+
+    [TestMethod]
+    public async Task ExportBatchCoreAsync_LegacyResolver_UsedWhenNoContextual()
+    {
+        // Arrange
+        bool legacyResolverCalled = false;
+        string? capturedAgentId = null;
+        string? capturedTenantId = null;
+
+        var options = new Agent365ExporterOptions
+        {
+            TokenResolver = (agentId, tenantId) =>
+            {
+                legacyResolverCalled = true;
+                capturedAgentId = agentId;
+                capturedTenantId = tenantId;
+                return Task.FromResult<string?>("legacy-token");
+            },
+            ContextualTokenResolver = null,
+        };
+
+        using var activity = CreateActivityWithAuid("tenant-1", "agent-1", "user-oid-123");
+        var groups = new List<(string TenantId, string AgentId, List<Activity> Activities)>
+        {
+            ("tenant-1", "agent-1", new List<Activity> { activity })
+        };
+
+        // Act
+        var result = await Core.ExportBatchCoreAsync(
+            groups,
+            ResourceBuilder.CreateEmpty().Build(),
+            options,
+            (agentId, tenantId) => options.TokenResolver!(agentId, tenantId),
+            request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+
+        // Assert
+        result.Should().Be(ExportResult.Success);
+        legacyResolverCalled.Should().BeTrue();
+        capturedAgentId.Should().Be("agent-1");
+        capturedTenantId.Should().Be("tenant-1");
+    }
+
+    [TestMethod]
+    public async Task ExportBatchCoreAsync_ContextualResolver_NullAuid_InS2SScenario()
+    {
+        // Arrange
+        string? capturedAuid = "sentinel";
+
+        var options = new Agent365ExporterOptions
+        {
+            ContextualTokenResolver = ctx =>
+            {
+                capturedAuid = ctx.Identity.AgenticUserId;
+                return Task.FromResult<string?>("token");
+            },
+        };
+
+        // Activity without AUID tag
+        using var activity = CreateActivityWithAuid("tenant-1", "agent-1", null);
+        var groups = new List<(string TenantId, string AgentId, List<Activity> Activities)>
+        {
+            ("tenant-1", "agent-1", new List<Activity> { activity })
+        };
+
+        // Act
+        var result = await Core.ExportBatchCoreAsync(
+            groups,
+            ResourceBuilder.CreateEmpty().Build(),
+            options,
+            (_, _) => Task.FromResult<string?>(null),
+            request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+
+        // Assert
+        result.Should().Be(ExportResult.Success);
+        capturedAuid.Should().BeNull("S2S scenario should pass null AgenticUserId");
+    }
+
+    [TestMethod]
+    public async Task ExportBatchCoreAsync_ContextualResolver_ReturnsNull_Fails()
+    {
+        // Arrange
+        var options = new Agent365ExporterOptions
+        {
+            ContextualTokenResolver = ctx => Task.FromResult<string?>(null),
+        };
+
+        using var activity = CreateActivityWithAuid("tenant-1", "agent-1", "user-oid-123");
+        var groups = new List<(string TenantId, string AgentId, List<Activity> Activities)>
+        {
+            ("tenant-1", "agent-1", new List<Activity> { activity })
+        };
+
+        // Act
+        var result = await Core.ExportBatchCoreAsync(
+            groups,
+            ResourceBuilder.CreateEmpty().Build(),
+            options,
+            (_, _) => Task.FromResult<string?>(null),
+            request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+
+        // Assert
+        result.Should().Be(ExportResult.Failure, "null token should result in failure");
+    }
+
+    [TestMethod]
+    public async Task ExportBatchCoreAsync_ContextualResolver_Throws_Fails()
+    {
+        // Arrange
+        var options = new Agent365ExporterOptions
+        {
+            ContextualTokenResolver = ctx => throw new InvalidOperationException("auth error"),
+        };
+
+        using var activity = CreateActivityWithAuid("tenant-1", "agent-1", "user-oid-123");
+        var groups = new List<(string TenantId, string AgentId, List<Activity> Activities)>
+        {
+            ("tenant-1", "agent-1", new List<Activity> { activity })
+        };
+
+        // Act
+        var result = await Core.ExportBatchCoreAsync(
+            groups,
+            ResourceBuilder.CreateEmpty().Build(),
+            options,
+            (_, _) => Task.FromResult<string?>(null),
+            request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+
+        // Assert
+        result.Should().Be(ExportResult.Failure, "exception in resolver should not crash, but fail export");
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static Activity CreateActivityWithAuid(string? tenantId, string? agentId, string? agenticUserId)
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Agent365Sdk.ContextualTest",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStarted = _ => { },
+            ActivityStopped = _ => { }
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var source = new ActivitySource("Agent365Sdk.ContextualTest");
+        var activity = source.StartActivity("test-span", ActivityKind.Client)!;
+
+        activity.SetTag(OpenTelemetryConstants.GenAiOperationNameKey, "invoke_agent");
+
+        if (tenantId != null)
+            activity.SetTag(OpenTelemetryConstants.TenantIdKey, tenantId);
+        if (agentId != null)
+            activity.SetTag(OpenTelemetryConstants.GenAiAgentIdKey, agentId);
+        if (agenticUserId != null)
+            activity.SetTag(OpenTelemetryConstants.AgentAUIDKey, agenticUserId);
+
+        activity.Stop();
+        return activity;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Introduces a non-breaking \AsyncContextualTokenResolver\ delegate and supporting types that allow the agentic user ID (AUID) to be passed alongside agent and tenant IDs during token resolution for the Agent365 exporter.

Ported from [microsoft/opentelemetry-distro-dotnet#101](https://github.com/microsoft/opentelemetry-distro-dotnet/pull/101).

## Changes

- **\AgentIdentity\** — New class with \AgentId\ and optional \AgenticUserId\ (null in S2S scenarios)
- **\TokenResolverContext\** — Context object providing \Identity\ + \TenantId\ for cache keys
- **\AsyncContextualTokenResolver\** — New delegate on \Agent365ExporterOptions\ that takes precedence over the legacy \TokenResolver\ when set
- **\Agent365ExporterCore\** — Updated to prefer \ContextualTokenResolver\; extracts AUID from the first activity in each group
- **\Agent365Exporter\ / \Agent365ExporterAsync\** — Relaxed constructor validation to accept either resolver
- **\ApplyGuardrailOperationName\** — Added to the exported genAI operation names set
- **14 unit tests** covering types, constructor validation, and resolver precedence

## Non-breaking

Existing code using \TokenResolver\ continues to work unchanged. \ContextualTokenResolver\ is opt-in and takes precedence only when explicitly set.

## Testing

- All 331 observability runtime tests pass
- Full solution (713 tests) passes with zero warnings