### PR TITLE
 Add MCP connection-readiness gating and surface setup URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ Both `Agent365.Observability.OtelWrite` (Delegated) and `Agent365.Observability.
 ## [Unreleased]
 
 ### Added
+- **Microsoft.Agents.A365.Tooling** - MCP connection-readiness gating
+  - Parses per-server and aggregate connection metadata (`allConnectionsUrl`, `missingConnectionsUrl`, `connectivityStatus`) from the tooling gateway discovery response, supporting both the legacy bare-array and wrapped `{ mcpServers, ... }` shapes
+  - `ListToolServersAsync` now throws the new public `McpConnectionsRequiredException` (exposing `MissingConnectionsUrl`, `ConnectivityStatus`, and `ServerNames`) when the aggregate connectivity status is present and not `Ready`; legacy responses and dev manifests are never gated
+  - The exception propagates through `EnumerateToolsFromServersAsync` / `EnumerateAllToolsAsync` and the framework extensions so callers can surface the setup URL to the user
+  - `MCPServerConfig` extended with `allConnectionsUrl`, `missingConnectionsUrl`, and `connectivityStatus`
 - **Microsoft.Agents.A365.Tooling** - V1/V2 per-audience token support for MCP servers
   - `MCPServerConfig` extended with `audience`, `scope`, `publisher`, and `Headers` fields
   - `IMcpTokenProvider` interface for pluggable OAuth token acquisition

--- a/src/Tests/Microsoft.Agents.A365.Tooling.Core.Tests/McpToolServerConfigurationService_ConnectionGatingTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Tooling.Core.Tests/McpToolServerConfigurationService_ConnectionGatingTests.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using FluentAssertions;
 using Microsoft.Agents.A365.Tooling.Models;
 using Microsoft.Agents.A365.Tooling.Services;
+using Microsoft.Agents.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -219,6 +220,51 @@ public class McpToolServerConfigurationService_ConnectionGatingTests
         servers.Should().ContainSingle();
     }
 
+    // ─── Exception propagation through enumeration ───────────────────────────
+
+    [Fact]
+    public async Task EnumerateToolsFromServersAsync_NoTokenProvider_PropagatesConnectionsRequired()
+    {
+        var mockService = CreatePartialMock();
+        mockService
+            .Setup(x => x.ListToolServersAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<ToolOptions>()))
+            .ThrowsAsync(new McpConnectionsRequiredException("https://missing", "Pending", new[] { "srv" }));
+
+        await Assert.ThrowsAsync<McpConnectionsRequiredException>(() =>
+            mockService.Object.EnumerateToolsFromServersAsync(
+                "agent-id", "auth-token", new Mock<ITurnContext>().Object, new ToolOptions()));
+    }
+
+    [Fact]
+    public async Task EnumerateToolsFromServersAsync_WithTokenProvider_PropagatesConnectionsRequired()
+    {
+        var mockService = CreatePartialMock();
+        mockService
+            .Setup(x => x.ListToolServersAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<ToolOptions>()))
+            .ThrowsAsync(new McpConnectionsRequiredException("https://missing", "Pending", new[] { "srv" }));
+
+        await Assert.ThrowsAsync<McpConnectionsRequiredException>(() =>
+            mockService.Object.EnumerateToolsFromServersAsync(
+                "agent-id", "auth-token", new Mock<IMcpTokenProvider>().Object,
+                new Mock<ITurnContext>().Object, new ToolOptions()));
+    }
+
+    [Fact]
+    public async Task EnumerateToolsFromServersAsync_GenericFailure_StillReturnsEmpty()
+    {
+        // Regression guard: non-gating failures remain swallowed (return empty) — unchanged behavior.
+        var mockService = CreatePartialMock();
+        mockService
+            .Setup(x => x.ListToolServersAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<ToolOptions>()))
+            .ThrowsAsync(new Exception("network"));
+
+        var (servers, toolsByServer) = await mockService.Object.EnumerateToolsFromServersAsync(
+            "agent-id", "auth-token", new Mock<ITurnContext>().Object, new ToolOptions());
+
+        servers.Should().BeEmpty();
+        toolsByServer.Should().BeEmpty();
+    }
+
     // ─── Helpers ─────────────────────────────────────────────────────────────
 
     private static McpDiscoveryResult ParseGateway(string json)
@@ -226,6 +272,15 @@ public class McpToolServerConfigurationService_ConnectionGatingTests
         using var doc = JsonDocument.Parse(json);
         return McpToolServerConfigurationService.ParseGatewayResponse(doc.RootElement);
     }
+
+    private static Mock<McpToolServerConfigurationService> CreatePartialMock() =>
+        new Mock<McpToolServerConfigurationService>(
+            MockBehavior.Default,
+            new Mock<ILogger<IMcpToolServerConfigurationService>>().Object,
+            new Mock<IConfiguration>().Object,
+            new Mock<IServiceProvider>().Object,
+            new Mock<IHttpClientFactory>().Object)
+        { CallBase = true };
 
     private static FakeHttpMessageHandler Respond(string json) =>
         new(_ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(json) });

--- a/src/Tests/Microsoft.Agents.A365.Tooling.Core.Tests/McpToolServerConfigurationService_ConnectionGatingTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Tooling.Core.Tests/McpToolServerConfigurationService_ConnectionGatingTests.cs
@@ -182,6 +182,74 @@ public class McpToolServerConfigurationService_ConnectionGatingTests
             .Which.ConnectivityStatus.Should().Be("Frozen");
     }
 
+    [Fact]
+    public void EnforceConnectionReadiness_AggregateReadyButPerServerPending_DoesNotThrow()
+    {
+        // Gating is aggregate-only by design: a per-server Pending does not block the turn when the
+        // gateway reports the aggregate connectivity status as Ready.
+        var service = CreateService();
+        var discovery = new McpDiscoveryResult(
+            new List<MCPServerConfig>
+            {
+                new() { mcpServerName = "srv", id = "id-1", url = "http://s", connectivityStatus = "Pending" },
+            },
+            connectivityStatus: "Ready");
+
+        var act = () => service.EnforceConnectionReadiness(discovery);
+
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [InlineData("READY")]
+    [InlineData(" ready ")]
+    public void EnforceConnectionReadiness_ReadyStatusVariants_DoNotThrow(string status)
+    {
+        // Pins IsReadyStatus: comparison is case-insensitive and whitespace-tolerant.
+        var service = CreateService();
+        var discovery = new McpDiscoveryResult(new List<MCPServerConfig>(), connectivityStatus: status);
+
+        var act = () => service.EnforceConnectionReadiness(discovery);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void EnforceConnectionReadiness_PendingWithoutPerServerStatus_ThrowsWithEmptyServerNames()
+    {
+        var service = CreateService();
+        var discovery = new McpDiscoveryResult(
+            new List<MCPServerConfig>
+            {
+                new() { mcpServerName = "srv", id = "id-1", url = "http://s" },
+            },
+            connectivityStatus: "Pending");
+
+        var act = () => service.EnforceConnectionReadiness(discovery);
+
+        var ex = act.Should().Throw<McpConnectionsRequiredException>().Which;
+        ex.ServerNames.Should().BeEmpty();
+        ex.Message.Should().Contain("(unknown)");
+    }
+
+    [Fact]
+    public void EnforceConnectionReadiness_PendingWithoutMissingUrl_ThrowsWithNullUrl()
+    {
+        // Every consumer's handler must survive a null MissingConnectionsUrl.
+        var service = CreateService();
+        var discovery = new McpDiscoveryResult(
+            new List<MCPServerConfig>
+            {
+                new() { mcpServerName = "srv", id = "id-1", url = "http://s", connectivityStatus = "Pending" },
+            },
+            connectivityStatus: "Pending");
+
+        var act = () => service.EnforceConnectionReadiness(discovery);
+
+        act.Should().Throw<McpConnectionsRequiredException>()
+            .Which.MissingConnectionsUrl.Should().BeNull();
+    }
+
     // ─── ListToolServersAsync (end-to-end via gateway) ───────────────────────
 
     [Fact]

--- a/src/Tests/Microsoft.Agents.A365.Tooling.Core.Tests/McpToolServerConfigurationService_ConnectionGatingTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.Tooling.Core.Tests/McpToolServerConfigurationService_ConnectionGatingTests.cs
@@ -1,0 +1,259 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Agents.A365.Tooling.Models;
+using Microsoft.Agents.A365.Tooling.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Agents.A365.Tooling.Core.Tests;
+
+/// <summary>
+/// Tests for MCP connection gating: gateway response parsing (wrapped + legacy), aggregate/per-server
+/// connection metadata, and the <see cref="McpConnectionsRequiredException"/> raised by
+/// <c>ListToolServersAsync</c> when configured servers are not connection-ready.
+/// </summary>
+public class McpToolServerConfigurationService_ConnectionGatingTests
+{
+    private const string WrappedPendingJson = """
+    {
+      "mcpServers": [
+        {
+          "mcpServerName": "mcp_Salesforce",
+          "id": "id-1",
+          "url": "https://s/mcp_Salesforce",
+          "scope": "McpServers.Salesforce.All",
+          "audience": "",
+          "allConnectionsUrl": "https://all/sf",
+          "missingConnectionsUrl": "https://missing/sf",
+          "connectivityStatus": "Pending"
+        }
+      ],
+      "allConnectionsUrl": "https://all",
+      "missingConnectionsUrl": "https://missing",
+      "connectivityStatus": "Pending"
+    }
+    """;
+
+    private const string WrappedReadyJson = """
+    {
+      "mcpServers": [
+        {
+          "mcpServerName": "s",
+          "id": "id-1",
+          "url": "https://s",
+          "allConnectionsUrl": "https://all",
+          "missingConnectionsUrl": "https://missing",
+          "connectivityStatus": "Ready"
+        }
+      ],
+      "allConnectionsUrl": "https://all",
+      "missingConnectionsUrl": "https://missing",
+      "connectivityStatus": "Ready"
+    }
+    """;
+
+    private const string LegacyArrayJson = """
+    [ { "mcpServerName": "s", "id": "id-1", "url": "https://s" } ]
+    """;
+
+    // ─── ParseGatewayResponse ────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseGatewayResponse_Wrapped_ParsesServersAndAggregateMetadata()
+    {
+        var result = ParseGateway(WrappedPendingJson);
+
+        var server = result.Servers.Should().ContainSingle().Subject;
+        server.mcpServerName.Should().Be("mcp_Salesforce");
+        server.allConnectionsUrl.Should().Be("https://all/sf");
+        server.missingConnectionsUrl.Should().Be("https://missing/sf");
+        server.connectivityStatus.Should().Be("Pending");
+
+        result.AllConnectionsUrl.Should().Be("https://all");
+        result.MissingConnectionsUrl.Should().Be("https://missing");
+        result.ConnectivityStatus.Should().Be("Pending");
+    }
+
+    [Fact]
+    public void ParseGatewayResponse_Ready_NullsMissingConnectionsUrl()
+    {
+        var result = ParseGateway(WrappedReadyJson);
+
+        var server = result.Servers.Should().ContainSingle().Subject;
+        server.connectivityStatus.Should().Be("Ready");
+        server.missingConnectionsUrl.Should().BeNull();
+
+        result.ConnectivityStatus.Should().Be("Ready");
+        result.MissingConnectionsUrl.Should().BeNull();
+        result.AllConnectionsUrl.Should().Be("https://all");
+    }
+
+    [Fact]
+    public void ParseGatewayResponse_LegacyArray_ReturnsServersWithoutAggregate()
+    {
+        var result = ParseGateway(LegacyArrayJson);
+
+        result.Servers.Should().ContainSingle();
+        result.ConnectivityStatus.Should().BeNull();
+        result.AllConnectionsUrl.Should().BeNull();
+        result.MissingConnectionsUrl.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseGatewayResponse_EmptyMcpServers_ReturnsEmptyWithAggregate()
+    {
+        var result = ParseGateway("""{ "mcpServers": [], "connectivityStatus": "Ready" }""");
+
+        result.Servers.Should().BeEmpty();
+        result.ConnectivityStatus.Should().Be("Ready");
+    }
+
+    [Fact]
+    public void ParseGatewayResponse_UnexpectedStructure_Throws()
+    {
+        Action act = () => ParseGateway("""{ "foo": 1 }""");
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*Unexpected JSON structure*");
+    }
+
+    // ─── EnforceConnectionReadiness ──────────────────────────────────────────
+
+    [Fact]
+    public void EnforceConnectionReadiness_Pending_ThrowsWithDetails()
+    {
+        var service = CreateService();
+        var discovery = new McpDiscoveryResult(
+            new List<MCPServerConfig>
+            {
+                new() { mcpServerName = "pending-srv", id = "id-1", url = "http://p", connectivityStatus = "Pending" },
+                new() { mcpServerName = "ready-srv", id = "id-2", url = "http://r", connectivityStatus = "Ready" },
+            },
+            allConnectionsUrl: "https://all",
+            missingConnectionsUrl: "https://missing",
+            connectivityStatus: "Pending");
+
+        var act = () => service.EnforceConnectionReadiness(discovery);
+
+        var ex = act.Should().Throw<McpConnectionsRequiredException>().Which;
+        ex.ConnectivityStatus.Should().Be("Pending");
+        ex.MissingConnectionsUrl.Should().Be("https://missing");
+        ex.ServerNames.Should().ContainSingle().Which.Should().Be("pending-srv");
+    }
+
+    [Fact]
+    public void EnforceConnectionReadiness_Ready_DoesNotThrow()
+    {
+        var service = CreateService();
+        var discovery = new McpDiscoveryResult(new List<MCPServerConfig>(), connectivityStatus: "Ready");
+
+        var act = () => service.EnforceConnectionReadiness(discovery);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void EnforceConnectionReadiness_NullStatus_DoesNotThrow()
+    {
+        var service = CreateService();
+        var discovery = new McpDiscoveryResult(new List<MCPServerConfig>(), connectivityStatus: null);
+
+        var act = () => service.EnforceConnectionReadiness(discovery);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void EnforceConnectionReadiness_UnknownStatus_Throws()
+    {
+        var service = CreateService();
+        var discovery = new McpDiscoveryResult(new List<MCPServerConfig>(), connectivityStatus: "Frozen");
+
+        var act = () => service.EnforceConnectionReadiness(discovery);
+
+        act.Should().Throw<McpConnectionsRequiredException>()
+            .Which.ConnectivityStatus.Should().Be("Frozen");
+    }
+
+    // ─── ListToolServersAsync (end-to-end via gateway) ───────────────────────
+
+    [Fact]
+    public async Task ListToolServersAsync_PendingGateway_ThrowsConnectionsRequired()
+    {
+        var service = CreateService(Respond(WrappedPendingJson));
+
+        var ex = await Assert.ThrowsAsync<McpConnectionsRequiredException>(
+            () => service.ListToolServersAsync("agent-123", "tok", new ToolOptions()));
+
+        ex.ConnectivityStatus.Should().Be("Pending");
+        ex.MissingConnectionsUrl.Should().Be("https://missing");
+        ex.ServerNames.Should().Contain("mcp_Salesforce");
+    }
+
+    [Fact]
+    public async Task ListToolServersAsync_ReadyGateway_ReturnsServers()
+    {
+        var service = CreateService(Respond(WrappedReadyJson));
+
+        var servers = await service.ListToolServersAsync("agent-123", "tok", new ToolOptions());
+
+        var server = servers.Should().ContainSingle().Subject;
+        server.connectivityStatus.Should().Be("Ready");
+        server.missingConnectionsUrl.Should().BeNull();
+        server.allConnectionsUrl.Should().Be("https://all");
+    }
+
+    [Fact]
+    public async Task ListToolServersAsync_LegacyArrayGateway_ReturnsServersWithoutGating()
+    {
+        var service = CreateService(Respond(LegacyArrayJson));
+
+        var servers = await service.ListToolServersAsync("agent-123", "tok", new ToolOptions());
+
+        servers.Should().ContainSingle();
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    private static McpDiscoveryResult ParseGateway(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return McpToolServerConfigurationService.ParseGatewayResponse(doc.RootElement);
+    }
+
+    private static FakeHttpMessageHandler Respond(string json) =>
+        new(_ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(json) });
+
+    private static McpToolServerConfigurationService CreateService(FakeHttpMessageHandler? handler = null)
+    {
+        var config = new Mock<IConfiguration>();
+        config.Setup(c => c["MCP_PLATFORM_ENDPOINT"]).Returns("https://test.endpoint");
+
+        handler ??= Respond("[]");
+        var httpClient = new HttpClient(handler);
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+        return new McpToolServerConfigurationService(
+            new Mock<ILogger<IMcpToolServerConfigurationService>>().Object,
+            config.Object,
+            new Mock<IServiceProvider>().Object,
+            factory.Object);
+    }
+
+    private sealed class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+
+        public FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) => _responder = responder;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(_responder(request));
+    }
+}

--- a/src/Tooling/Core/Exceptions/McpConnectionsRequiredException.cs
+++ b/src/Tooling/Core/Exceptions/McpConnectionsRequiredException.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Agents.A365.Tooling
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Thrown when one or more configured MCP servers are not yet connection-ready.
+    /// The tooling gateway reports an aggregate connectivity status other than <c>Ready</c>
+    /// (for example, <c>Pending</c>) when the agent's MCP servers have downstream connections that the
+    /// user has not yet established. Callers should surface <see cref="MissingConnectionsUrl"/> to the
+    /// user to complete setup, then retry on a later turn once the connections are in place.
+    /// </summary>
+    public class McpConnectionsRequiredException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="McpConnectionsRequiredException"/> class.
+        /// </summary>
+        /// <param name="missingConnectionsUrl">URL the user can visit to set up the missing connections, when provided by the gateway.</param>
+        /// <param name="connectivityStatus">The aggregate connectivity status reported by the gateway (for example, <c>Pending</c>).</param>
+        /// <param name="serverNames">The names of the MCP servers that are not yet connection-ready.</param>
+        public McpConnectionsRequiredException(
+            string? missingConnectionsUrl,
+            string? connectivityStatus,
+            IReadOnlyList<string> serverNames)
+            : base(BuildMessage(missingConnectionsUrl, connectivityStatus, serverNames))
+        {
+            this.MissingConnectionsUrl = missingConnectionsUrl;
+            this.ConnectivityStatus = connectivityStatus;
+            this.ServerNames = serverNames;
+        }
+
+        /// <summary>Gets the URL the user can visit to set up the missing connections, or null when not provided.</summary>
+        public string? MissingConnectionsUrl { get; }
+
+        /// <summary>Gets the aggregate connectivity status reported by the gateway, or null when not provided.</summary>
+        public string? ConnectivityStatus { get; }
+
+        /// <summary>Gets the names of the MCP servers that are not yet connection-ready.</summary>
+        public IReadOnlyList<string> ServerNames { get; }
+
+        private static string BuildMessage(string? missingConnectionsUrl, string? connectivityStatus, IReadOnlyList<string> serverNames)
+        {
+            string serversText = serverNames is { Count: > 0 } ? string.Join(", ", serverNames) : "(unknown)";
+            return $"MCP servers [{serversText}] require connection setup (connectivityStatus={connectivityStatus}). " +
+                   $"Set up missing connections at: {missingConnectionsUrl}";
+        }
+    }
+}

--- a/src/Tooling/Core/Exceptions/McpConnectionsRequiredException.cs
+++ b/src/Tooling/Core/Exceptions/McpConnectionsRequiredException.cs
@@ -38,7 +38,10 @@ namespace Microsoft.Agents.A365.Tooling
         /// <summary>Gets the aggregate connectivity status reported by the gateway, or null when not provided.</summary>
         public string? ConnectivityStatus { get; }
 
-        /// <summary>Gets the names of the MCP servers that are not yet connection-ready.</summary>
+        /// <summary>
+        /// Gets the names of the MCP servers that are not yet connection-ready. May be empty when the
+        /// gateway reports only an aggregate connectivity status without per-server detail.
+        /// </summary>
         public IReadOnlyList<string> ServerNames { get; }
 
         private static string BuildMessage(string? missingConnectionsUrl, string? connectivityStatus, IReadOnlyList<string> serverNames)

--- a/src/Tooling/Core/Models/MCPServerConfig.cs
+++ b/src/Tooling/Core/Models/MCPServerConfig.cs
@@ -43,6 +43,26 @@ namespace Microsoft.Agents.A365.Tooling.Models
         public string? publisher { get; set; }
 
         /// <summary>
+        /// Gets or sets the URL containing the deduped union of all connectors required for this MCP
+        /// server to operate. Populated by the discovery endpoint (<c>discoverMCPServers</c>); null
+        /// when not supplied (for example, on the basic server-list path).
+        /// </summary>
+        public string? allConnectionsUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL containing the deduped union of only the connectors required for this
+        /// MCP server that the connected user has not yet set up. Null when <c>connectivityStatus</c>
+        /// is <c>Ready</c> (no setup needed) or when not supplied.
+        /// </summary>
+        public string? missingConnectionsUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the connectivity status for this MCP server (for example, <c>Ready</c> when all
+        /// required connectors are already connected). Compare case-insensitively. Null when not supplied.
+        /// </summary>
+        public string? connectivityStatus { get; set; }
+
+        /// <summary>
         /// Gets or sets per-server HTTP headers, including the Authorization header populated
         /// by <c>AttachPerAudienceTokensAsync</c> before tool connections are established.
         /// Null until token attachment has run; callers should treat a missing Authorization

--- a/src/Tooling/Core/Models/McpDiscoveryResult.cs
+++ b/src/Tooling/Core/Models/McpDiscoveryResult.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Agents.A365.Tooling.Models
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Internal result of MCP server discovery from the tooling gateway. Carries the parsed server
+    /// list plus the response-level (aggregate) connection metadata used for connection gating.
+    /// Sources that predate the connection fields (legacy bare-array gateway responses, dev-mode
+    /// manifests) leave the aggregate fields null.
+    /// </summary>
+    internal sealed class McpDiscoveryResult
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="McpDiscoveryResult"/> class.
+        /// </summary>
+        /// <param name="servers">The parsed MCP server configurations.</param>
+        /// <param name="allConnectionsUrl">Aggregate URL for all required connectors, or null.</param>
+        /// <param name="missingConnectionsUrl">Aggregate URL for missing connectors, or null.</param>
+        /// <param name="connectivityStatus">Aggregate connectivity status, or null when not supplied.</param>
+        public McpDiscoveryResult(
+            List<MCPServerConfig> servers,
+            string? allConnectionsUrl = null,
+            string? missingConnectionsUrl = null,
+            string? connectivityStatus = null)
+        {
+            this.Servers = servers;
+            this.AllConnectionsUrl = allConnectionsUrl;
+            this.MissingConnectionsUrl = missingConnectionsUrl;
+            this.ConnectivityStatus = connectivityStatus;
+        }
+
+        /// <summary>Gets the parsed MCP server configurations.</summary>
+        public List<MCPServerConfig> Servers { get; }
+
+        /// <summary>Gets the aggregate URL covering all connectors required across all servers, or null.</summary>
+        public string? AllConnectionsUrl { get; }
+
+        /// <summary>Gets the aggregate URL covering only the connectors still missing across all servers, or null.</summary>
+        public string? MissingConnectionsUrl { get; }
+
+        /// <summary>Gets the aggregate connectivity status across all servers, or null when not supplied.</summary>
+        public string? ConnectivityStatus { get; }
+    }
+}

--- a/src/Tooling/Core/Services/IMcpToolServerConfigurationService.cs
+++ b/src/Tooling/Core/Services/IMcpToolServerConfigurationService.cs
@@ -84,6 +84,7 @@ namespace Microsoft.Agents.A365.Tooling.Services
         /// <param name="turnContext">Turn context for the current request.</param>
         /// <param name="toolOptions">Tool options including user agent configuration.</param>
         /// <returns>A tuple containing server configurations and a dictionary mapping server names to their available tools.</returns>
+        /// <exception cref="Microsoft.Agents.A365.Tooling.McpConnectionsRequiredException">Thrown when configured MCP servers report missing downstream connections (aggregate connectivity status other than "Ready").</exception>
         Task<(List<MCPServerConfig> Servers, Dictionary<string, IList<McpClientTool>> ToolsByServer)> EnumerateToolsFromServersAsync(string agentInstanceId, string authToken, ITurnContext turnContext, ToolOptions toolOptions);
 
         /// <summary>
@@ -97,6 +98,7 @@ namespace Microsoft.Agents.A365.Tooling.Services
         /// <param name="turnContext">Turn context for the current request.</param>
         /// <param name="toolOptions">Tool options including user agent configuration.</param>
         /// <returns>A tuple containing server configurations and a dictionary mapping server names to their available tools.</returns>
+        /// <exception cref="Microsoft.Agents.A365.Tooling.McpConnectionsRequiredException">Thrown when configured MCP servers report missing downstream connections (aggregate connectivity status other than "Ready").</exception>
         Task<(List<MCPServerConfig> Servers, Dictionary<string, IList<McpClientTool>> ToolsByServer)> EnumerateToolsFromServersAsync(string agentInstanceId, string authToken, IMcpTokenProvider tokenProvider, ITurnContext turnContext, ToolOptions toolOptions);
 
         /// <summary>
@@ -107,6 +109,7 @@ namespace Microsoft.Agents.A365.Tooling.Services
         /// <param name="turnContext">Turn context for the current request.</param>
         /// <param name="toolOptions">Tool options including user agent configuration.</param>
         /// <returns>A flat list of all MCP tools from all configured servers.</returns>
+        /// <exception cref="Microsoft.Agents.A365.Tooling.McpConnectionsRequiredException">Thrown when configured MCP servers report missing downstream connections (aggregate connectivity status other than "Ready").</exception>
         Task<IList<McpClientTool>> EnumerateAllToolsAsync(string agentInstanceId, string authToken, ITurnContext turnContext, ToolOptions toolOptions);
     }
 }

--- a/src/Tooling/Core/Services/IMcpToolServerConfigurationService.cs
+++ b/src/Tooling/Core/Services/IMcpToolServerConfigurationService.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Agents.A365.Tooling.Services
         /// <param name="agentInstanceId">Agent instance Id for the agent.</param>
         /// <param name="authToken">Auth token to access the MCP servers</param>
         /// <returns>Returns the list of MCP Servers that are configured.</returns>
+        /// <exception cref="Microsoft.Agents.A365.Tooling.McpConnectionsRequiredException">Thrown when configured MCP servers report missing downstream connections (aggregate connectivity status other than "Ready").</exception>
         Task<List<MCPServerConfig>> ListToolServersAsync(string agentInstanceId, string authToken);
 
         /// <summary>
@@ -28,6 +29,7 @@ namespace Microsoft.Agents.A365.Tooling.Services
         /// <param name="authToken">Auth token to access the MCP servers</param>
         /// <param name="toolOptions">Tool options for listing servers.</param>
         /// <returns>Returns the list of MCP Servers that are configured.</returns>
+        /// <exception cref="Microsoft.Agents.A365.Tooling.McpConnectionsRequiredException">Thrown when configured MCP servers report missing downstream connections (aggregate connectivity status other than "Ready").</exception>
         Task<List<MCPServerConfig>> ListToolServersAsync(string agentInstanceId, string authToken, ToolOptions toolOptions);
 
         /// <summary>

--- a/src/Tooling/Core/Services/McpToolServerConfigurationService.ToolEnumeration.cs
+++ b/src/Tooling/Core/Services/McpToolServerConfigurationService.ToolEnumeration.cs
@@ -38,6 +38,12 @@ namespace Microsoft.Agents.A365.Tooling.Services
                     tokenProvider,
                     toolOptions).ConfigureAwait(false);
             }
+            catch (McpConnectionsRequiredException)
+            {
+                // Connection-readiness gating must reach the agent's turn handler so it can prompt
+                // the user with the setup URL. Never swallow it as a generic listing failure.
+                throw;
+            }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to list MCP tool servers for AgentInstanceId={AgentInstanceId}", agentInstanceId);
@@ -130,6 +136,12 @@ namespace Microsoft.Agents.A365.Tooling.Services
                     agentInstanceId,
                     authToken,
                     toolOptions).ConfigureAwait(false);
+            }
+            catch (McpConnectionsRequiredException)
+            {
+                // Connection-readiness gating must reach the agent's turn handler so it can prompt
+                // the user with the setup URL. Never swallow it as a generic listing failure.
+                throw;
             }
             catch (Exception ex)
             {

--- a/src/Tooling/Core/Services/McpToolServerConfigurationService.cs
+++ b/src/Tooling/Core/Services/McpToolServerConfigurationService.cs
@@ -57,7 +57,19 @@ namespace Microsoft.Agents.A365.Tooling.Services
         /// <inheritdoc/>
         public virtual async Task<List<MCPServerConfig>> ListToolServersAsync(string agentInstanceId, string authToken, ToolOptions toolOptions)
         {
-            return IsDevScenario() ? GetMCPServersFromManifest() : await GetMCPServerFromToolingGatewayAsync(agentInstanceId, authToken, toolOptions);
+            if (IsDevScenario())
+            {
+                // Dev manifests carry no connection metadata, so connection gating never applies.
+                return GetMCPServersFromManifest();
+            }
+
+            McpDiscoveryResult discovery = await GetMCPServerFromToolingGatewayAsync(agentInstanceId, authToken, toolOptions);
+
+            // Gate execution when configured MCP servers are not connection-ready. Runs before token
+            // attachment because readiness is independent of tokens.
+            EnforceConnectionReadiness(discovery);
+
+            return discovery.Servers;
         }
 
         /// <summary>
@@ -177,7 +189,7 @@ namespace Microsoft.Agents.A365.Tooling.Services
             }
         }
 
-        private async Task<List<MCPServerConfig>> GetMCPServerFromToolingGatewayAsync(
+        private async Task<McpDiscoveryResult> GetMCPServerFromToolingGatewayAsync(
             string agentInstanceId, string authToken, ToolOptions toolOptions)
         {
             string configEndpoint = Utility.GetToolingGatewayForDigitalWorker(agentInstanceId, this._configuration);
@@ -201,23 +213,9 @@ namespace Microsoft.Agents.A365.Tooling.Services
                     PropertyNameCaseInsensitive = true
                 };
 
-                // Single parse approach
                 var jsonDoc = JsonSerializer.Deserialize<JsonElement>(response, options);
 
-                IEnumerable<JsonElement> serverElements = jsonDoc.ValueKind switch
-                {
-                    JsonValueKind.Array => jsonDoc.EnumerateArray(),
-                    JsonValueKind.Object when jsonDoc.TryGetProperty("mcpServers", out var servers)
-                                           && servers.ValueKind == JsonValueKind.Array
-                        => servers.EnumerateArray(),
-                    _ => throw new InvalidOperationException(
-                        $"Unexpected JSON structure. Expected array or object with 'mcpServers' property, got {jsonDoc.ValueKind}")
-                };
-
-                return serverElements
-                    .Select(ParseServerConfig)
-                    .Where(config => config != null)
-                    .ToList()!;
+                return ParseGatewayResponse(jsonDoc);
             }
             catch (HttpRequestException httpEx)
             {
@@ -285,6 +283,14 @@ namespace Microsoft.Agents.A365.Tooling.Services
                     publisher = publisherElement.GetString();
                 }
 
+                string? allConnectionsUrl = GetStringPropertyCaseInsensitive(serverElement, "allConnectionsUrl");
+                string? missingConnectionsUrl = GetStringPropertyCaseInsensitive(serverElement, "missingConnectionsUrl");
+                string? connectivityStatus = GetStringPropertyCaseInsensitive(serverElement, "connectivityStatus");
+                if (IsReadyStatus(connectivityStatus))
+                {
+                    missingConnectionsUrl = null;
+                }
+
                 // Both Name and Endpoint are required
                 if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(endpoint))
                 {
@@ -298,7 +304,10 @@ namespace Microsoft.Agents.A365.Tooling.Services
                     id = id ?? string.Empty,
                     scope = scope,
                     audience = audience,
-                    publisher = publisher
+                    publisher = publisher,
+                    allConnectionsUrl = allConnectionsUrl,
+                    missingConnectionsUrl = missingConnectionsUrl,
+                    connectivityStatus = connectivityStatus
                 };
             }
             catch (Exception)
@@ -306,6 +315,141 @@ namespace Microsoft.Agents.A365.Tooling.Services
                 // Return null if parsing fails for this individual server
                 return null;
             }
+        }
+
+        /// <summary>
+        /// Raises <see cref="McpConnectionsRequiredException"/> when the aggregate connectivity status
+        /// indicates that one or more required downstream connections are missing.
+        /// </summary>
+        /// <param name="discovery">The discovery result carrying aggregate and per-server status.</param>
+        /// <remarks>
+        /// Blocks only when the response-level connectivity status is present and not <c>Ready</c>
+        /// (for example, <c>Pending</c>). Absent status (legacy raw-array gateway responses and
+        /// dev-mode manifests) is always treated as ready, so those paths are never gated. The
+        /// non-<c>Ready</c> check is intentionally defensive against any unexpected future status value.
+        /// </remarks>
+        internal void EnforceConnectionReadiness(McpDiscoveryResult discovery)
+        {
+            string? status = discovery.ConnectivityStatus;
+            if (string.IsNullOrWhiteSpace(status) || IsReadyStatus(status))
+            {
+                return;
+            }
+
+            List<string> serverNames = discovery.Servers
+                .Where(s => !string.IsNullOrWhiteSpace(s.connectivityStatus) && !IsReadyStatus(s.connectivityStatus))
+                .Select(s => string.IsNullOrEmpty(s.mcpServerName) ? s.id : s.mcpServerName)
+                .ToList();
+
+            this._logger.LogInformation(
+                "MCP connection gate blocking turn: connectivityStatus={ConnectivityStatus}, servers={ServerNames}",
+                status,
+                string.Join(", ", serverNames));
+
+            throw new McpConnectionsRequiredException(discovery.MissingConnectionsUrl, status, serverNames);
+        }
+
+        /// <summary>
+        /// Parses a tooling gateway response into an <see cref="McpDiscoveryResult"/>. Supports both the
+        /// legacy bare-array shape (servers only, no connection metadata) and the wrapped object shape
+        /// <c>{ "mcpServers": [...], allConnectionsUrl, missingConnectionsUrl, connectivityStatus }</c>.
+        /// </summary>
+        /// <param name="root">The root JSON element of the gateway response.</param>
+        /// <returns>The parsed discovery result with servers and aggregate connection metadata.</returns>
+        internal static McpDiscoveryResult ParseGatewayResponse(JsonElement root)
+        {
+            if (root.ValueKind == JsonValueKind.Array)
+            {
+                // Legacy bare-array: servers only, no aggregate connection metadata.
+                List<MCPServerConfig> legacyServers = root.EnumerateArray()
+                    .Select(ParseServerConfig)
+                    .Where(config => config != null)
+                    .ToList()!;
+                return new McpDiscoveryResult(legacyServers);
+            }
+
+            if (root.ValueKind == JsonValueKind.Object &&
+                TryGetPropertyCaseInsensitive(root, "mcpServers", out var serversElement) &&
+                serversElement.ValueKind == JsonValueKind.Array)
+            {
+                List<MCPServerConfig> servers = serversElement.EnumerateArray()
+                    .Select(ParseServerConfig)
+                    .Where(config => config != null)
+                    .ToList()!;
+
+                string? connectivityStatus = GetStringPropertyCaseInsensitive(root, "connectivityStatus");
+                string? allConnectionsUrl = GetStringPropertyCaseInsensitive(root, "allConnectionsUrl");
+                string? missingConnectionsUrl = GetStringPropertyCaseInsensitive(root, "missingConnectionsUrl");
+                if (IsReadyStatus(connectivityStatus))
+                {
+                    missingConnectionsUrl = null;
+                }
+
+                return new McpDiscoveryResult(servers, allConnectionsUrl, missingConnectionsUrl, connectivityStatus);
+            }
+
+            throw new InvalidOperationException(
+                $"Unexpected JSON structure. Expected array or object with 'mcpServers' property, got {root.ValueKind}");
+        }
+
+        /// <summary>
+        /// The connectivity status value indicating that all required connectors are already connected.
+        /// </summary>
+        private const string ReadyConnectivityStatus = "Ready";
+
+        /// <summary>
+        /// Determines whether a connectivity status value represents the ready state (case-insensitive).
+        /// </summary>
+        /// <param name="connectivityStatus">The connectivity status value to evaluate.</param>
+        /// <returns><c>true</c> when the value equals <c>Ready</c> ignoring case and surrounding whitespace.</returns>
+        private static bool IsReadyStatus(string? connectivityStatus) =>
+            !string.IsNullOrWhiteSpace(connectivityStatus) &&
+            connectivityStatus!.Trim().Equals(ReadyConnectivityStatus, StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Attempts to read a property from a JSON object using a case-insensitive name match. The
+        /// property name is trimmed to tolerate stray whitespace in the source schema.
+        /// </summary>
+        /// <param name="element">The JSON object to read from.</param>
+        /// <param name="propertyName">The property name to match (case-insensitive).</param>
+        /// <param name="value">The matched property value, or default when not found.</param>
+        /// <returns><c>true</c> when a matching property is found; otherwise <c>false</c>.</returns>
+        private static bool TryGetPropertyCaseInsensitive(JsonElement element, string propertyName, out JsonElement value)
+        {
+            value = default;
+            if (element.ValueKind != JsonValueKind.Object)
+            {
+                return false;
+            }
+
+            foreach (var property in element.EnumerateObject())
+            {
+                if (string.Equals(property.Name.Trim(), propertyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    value = property.Value;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Reads a string property from a JSON object using a case-insensitive name match, or null when
+        /// the property is absent or not a string.
+        /// </summary>
+        /// <param name="element">The JSON object to read from.</param>
+        /// <param name="propertyName">The property name to match (case-insensitive).</param>
+        /// <returns>The string value, or null when not present.</returns>
+        private static string? GetStringPropertyCaseInsensitive(JsonElement element, string propertyName)
+        {
+            if (TryGetPropertyCaseInsensitive(element, propertyName, out var value) &&
+                value.ValueKind == JsonValueKind.String)
+            {
+                return value.GetString();
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/src/Tooling/Core/Services/McpToolServerConfigurationService.cs
+++ b/src/Tooling/Core/Services/McpToolServerConfigurationService.cs
@@ -28,6 +28,11 @@ namespace Microsoft.Agents.A365.Tooling.Services
     /// </summary>
     public partial class McpToolServerConfigurationService : IMcpToolServerConfigurationService
     {
+        /// <summary>
+        /// The connectivity status value indicating that all required connectors are already connected.
+        /// </summary>
+        private const string ReadyConnectivityStatus = "Ready";
+
         private readonly ILogger<IMcpToolServerConfigurationService> _logger;
         private readonly IConfiguration _configuration;
         private readonly ILoggerFactory? _loggerFactory;
@@ -208,12 +213,9 @@ namespace Microsoft.Agents.A365.Tooling.Services
 
                 var response = await httpClient.GetStringAsync(configEndpoint);
 
-                var options = new JsonSerializerOptions
-                {
-                    PropertyNameCaseInsensitive = true
-                };
-
-                var jsonDoc = JsonSerializer.Deserialize<JsonElement>(response, options);
+                // PropertyNameCaseInsensitive does not affect JsonElement materialization, so parse
+                // into a JsonElement directly; case-insensitive lookups are handled in ParseGatewayResponse.
+                var jsonDoc = JsonSerializer.Deserialize<JsonElement>(response);
 
                 return ParseGatewayResponse(jsonDoc);
             }
@@ -341,7 +343,7 @@ namespace Microsoft.Agents.A365.Tooling.Services
                 .Select(s => string.IsNullOrEmpty(s.mcpServerName) ? s.id : s.mcpServerName)
                 .ToList();
 
-            this._logger.LogInformation(
+            this._logger.LogWarning(
                 "MCP connection gate blocking turn: connectivityStatus={ConnectivityStatus}, servers={ServerNames}",
                 status,
                 string.Join(", ", serverNames));
@@ -393,22 +395,17 @@ namespace Microsoft.Agents.A365.Tooling.Services
         }
 
         /// <summary>
-        /// The connectivity status value indicating that all required connectors are already connected.
-        /// </summary>
-        private const string ReadyConnectivityStatus = "Ready";
-
-        /// <summary>
         /// Determines whether a connectivity status value represents the ready state (case-insensitive).
         /// </summary>
         /// <param name="connectivityStatus">The connectivity status value to evaluate.</param>
         /// <returns><c>true</c> when the value equals <c>Ready</c> ignoring case and surrounding whitespace.</returns>
         private static bool IsReadyStatus(string? connectivityStatus) =>
             !string.IsNullOrWhiteSpace(connectivityStatus) &&
-            connectivityStatus!.Trim().Equals(ReadyConnectivityStatus, StringComparison.OrdinalIgnoreCase);
+            connectivityStatus.Trim().Equals(ReadyConnectivityStatus, StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
-        /// Attempts to read a property from a JSON object using a case-insensitive name match. The
-        /// property name is trimmed to tolerate stray whitespace in the source schema.
+        /// Attempts to read a property from a JSON object using a case-insensitive (ordinal) name match,
+        /// matching <c>JsonSerializerOptions.PropertyNameCaseInsensitive</c> semantics.
         /// </summary>
         /// <param name="element">The JSON object to read from.</param>
         /// <param name="propertyName">The property name to match (case-insensitive).</param>
@@ -424,7 +421,7 @@ namespace Microsoft.Agents.A365.Tooling.Services
 
             foreach (var property in element.EnumerateObject())
             {
-                if (string.Equals(property.Name.Trim(), propertyName, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
                 {
                     value = property.Value;
                     return true;

--- a/src/Tooling/Extensions/AgentFramework/CHANGELOG.md
+++ b/src/Tooling/Extensions/AgentFramework/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Microsoft.Agents.A365.Tooling.Extensions.AgentFramework** - V2 per-audience token support
   - `McpToolRegistrationService.AddToolServersToAgent` and `GetMcpToolsAsync` now instantiate `AgenticMcpTokenProvider` and use the V2-aware `EnumerateToolsFromServersAsync` overload, so each V2 MCP server receives its own audience-scoped Bearer token instead of the shared ATG token
+- **Microsoft.Agents.A365.Tooling.Extensions.AgentFramework** - MCP connection-readiness gating now propagates
+  - `AddToolServersToAgent` and `GetMcpToolsAsync` allow `McpConnectionsRequiredException` to propagate when configured MCP servers are not connection-ready, so callers can surface the setup URL to the user instead of receiving an empty tool list
 
 
 ## [1.0.0] - 2025-01-16

--- a/src/Tooling/Extensions/AzureAIFoundry/CHANGELOG.md
+++ b/src/Tooling/Extensions/AzureAIFoundry/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Microsoft.Agents.A365.Tooling.Extensions.AzureAIFoundry** - V2 per-audience token support
   - `McpToolRegistrationService.AddToolServersToAgentAsync` now instantiates `AgenticMcpTokenProvider` and uses the V2-aware `GetMcpToolDefinitionsAndResourcesAsync` overload; each V2 MCP server's `MCPToolResource` is populated with its audience-scoped Bearer token instead of the shared ATG token
+- **Microsoft.Agents.A365.Tooling.Extensions.AzureAIFoundry** - MCP connection-readiness gating now propagates
+  - `AddToolServersToAgentAsync` allows `McpConnectionsRequiredException` to propagate when configured MCP servers are not connection-ready, so callers can surface the setup URL to the user instead of receiving an empty tool list
 
 ### Added
 - **Microsoft.Agents.A365.Tooling.AzureFoundry** - Azure Foundry integration tooling for MCP server management

--- a/src/Tooling/Extensions/SemanticKernel/CHANGELOG.md
+++ b/src/Tooling/Extensions/SemanticKernel/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Microsoft.Agents.A365.Tooling.Extensions.SemanticKernel** - V2 per-audience token support
   - `McpToolRegistrationService.AddToolServersToAgentAsync` now instantiates `AgenticMcpTokenProvider` and uses the V2-aware `EnumerateToolsFromServersAsync` overload, so each V2 MCP server receives its own audience-scoped Bearer token instead of the shared ATG token
   - OBO token acquisition is deferred until after the dev-mode check; in `Development` environments the `DevMcpTokenProvider` supplies tokens from environment variables (`BEARER_TOKEN_<SERVERNAME>` / `BEARER_TOKEN`) without requiring a working auth setup
+- **Microsoft.Agents.A365.Tooling.Extensions.SemanticKernel** - MCP connection-readiness gating now propagates
+  - `AddToolServersToAgentAsync` allows `McpConnectionsRequiredException` to propagate when configured MCP servers are not connection-ready, so callers can surface the setup URL to the user instead of receiving an empty tool list
 
 ### Added
 - **Microsoft.Agents.A365.Tooling.Extensions.SemanticKernel** - Semantic Kernel integration tooling for MCP server management


### PR DESCRIPTION
- Parse per-server and aggregate connection metadata (allConnectionsUrl, missingConnectionsUrl, connectivityStatus) from the tooling gateway response, supporting both the legacy bare-array and wrapped {mcpServers, ...} shapes.
- Carry aggregate metadata in an internal McpDiscoveryResult.
- Gate ListToolServersAsync: throw McpConnectionsRequiredException when the aggregate connectivity status is present and not "Ready". Dev-manifest and legacy responses are never gated.
- Add public McpConnectionsRequiredException (MissingConnectionsUrl, ConnectivityStatus, ServerNames).