### PR TITLE
Copy service.name baggage onto all span attributes

### DIFF
--- a/src/Observability/Runtime/Tracing/Processors/ActivityProcessor.cs
+++ b/src/Observability/Runtime/Tracing/Processors/ActivityProcessor.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Processors
             OpenTelemetryConstants.UserNameKey,
             OpenTelemetryConstants.UserEmailKey,
             OpenTelemetryConstants.CallerClientIpKey,
+            OpenTelemetryConstants.ServiceNameKey,
         };
 
         private static readonly string[] InvokeAgentAttributeKeys = new[]


### PR DESCRIPTION
## Summary
The `service.name` baggage value, set via `BaggageBuilder.OperationSource(...)`, was never copied onto span attributes because `ServiceNameKey` was missing from `ActivityProcessor`'s `AttributeKeys` allow-list. As a result, `OperationSource(...)` had no effect on emitted telemetry.

## Change
Added `OpenTelemetryConstants.ServiceNameKey` to the global `AttributeKeys` list in `ActivityProcessor`. `CoalesceTag` only applies the tag when the baggage value is non-empty, so it is copied to every span only when set.

## Audit
Reviewed all baggage keys written by `BaggageBuilder` and `TurnContextExtensions` against the processor allow-lists. `service.name` was the only baggage attribute set but not copied to spans; all others were already covered (`server.address`/`server.port` remain scoped to invoke_agent spans intentionally).

## Testing
- `dotnet build` succeeds
- All 331 Observability.Runtime tests pass